### PR TITLE
Reduce GC Alloc

### DIFF
--- a/LiteNetLib/LiteNetLib.csproj
+++ b/LiteNetLib/LiteNetLib.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Utils\NetDataReader.cs" />
     <Compile Include="Utils\NetDataWriter.cs" />
     <Compile Include="Utils\NetSerializer.cs" />
+    <Compile Include="Utils\Pool.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/LiteNetLib/NatPunchModule.cs
+++ b/LiteNetLib/NatPunchModule.cs
@@ -85,7 +85,9 @@ namespace LiteNetLib
             dw.Put(hostExternal);
             dw.Put(additionalInfo, MaxTokenLength);
 
-            _netBase.SendRaw(NetPacket.CreateRawPacket(PacketProperty.NatIntroduction, dw), clientExternal);
+            byte[] packet = NetPacket.CreateRawPacket(PacketProperty.NatIntroduction, dw);
+            _netBase.SendRaw(packet, clientExternal);
+            NetPacket.RecycleRawPacket(packet);
 
             //Second packet (client)
             //send to server
@@ -95,7 +97,9 @@ namespace LiteNetLib
             dw.Put(clientExternal);
             dw.Put(additionalInfo, MaxTokenLength);
 
-            _netBase.SendRaw(NetPacket.CreateRawPacket(PacketProperty.NatIntroduction, dw), hostExternal);
+            packet = NetPacket.CreateRawPacket(PacketProperty.NatIntroduction, dw);
+            _netBase.SendRaw(packet, hostExternal);
+            NetPacket.RecycleRawPacket(packet);
         }
 
         public void PollEvents()
@@ -134,7 +138,9 @@ namespace LiteNetLib
             dw.Put(additionalInfo, MaxTokenLength);
 
             //prepare packet
-            _netBase.SendRaw(NetPacket.CreateRawPacket(PacketProperty.NatIntroductionRequest, dw), masterServerEndPoint);
+            byte[] packet = NetPacket.CreateRawPacket(PacketProperty.NatIntroductionRequest, dw);
+            _netBase.SendRaw(packet, masterServerEndPoint);
+            NetPacket.RecycleRawPacket(packet);
         }
 
         private void HandleNatPunch(NetEndPoint senderEndPoint, NetDataReader dr)
@@ -171,14 +177,18 @@ namespace LiteNetLib
             // send internal punch
             writer.Put(hostByte);
             writer.Put(token);
-            _netBase.SendRaw(NetPacket.CreateRawPacket(PacketProperty.NatPunchMessage, writer), remoteInternal);
+            byte[] packet = NetPacket.CreateRawPacket(PacketProperty.NatPunchMessage, writer);
+            _netBase.SendRaw(packet, remoteInternal);
+            NetPacket.RecycleRawPacket(packet);
             NetUtils.DebugWrite(ConsoleColor.Cyan, "[NAT] internal punch sent to " + remoteInternal);
 
             // send external punch
             writer.Reset();
             writer.Put(hostByte);
             writer.Put(token);
-            _netBase.SendRaw(NetPacket.CreateRawPacket(PacketProperty.NatPunchMessage, writer), remoteExternal);
+            packet = NetPacket.CreateRawPacket(PacketProperty.NatPunchMessage, writer);
+            _netBase.SendRaw(packet, remoteExternal);
+            NetPacket.RecycleRawPacket(packet);
             NetUtils.DebugWrite(ConsoleColor.Cyan, "[NAT] external punch sent to " + remoteExternal);
         }
 

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -279,6 +279,7 @@ namespace LiteNetLib
                     Buffer.BlockCopy(data, start, disconnectPacket, 9, count);
                 }
                 SendRaw(disconnectPacket, peer.EndPoint);
+                NetPacket.RecycleRawPacket(disconnectPacket);
             }
             var netEvent = CreateEvent(NetEventType.Disconnect);
             netEvent.Peer = peer;
@@ -825,7 +826,9 @@ namespace LiteNetLib
             if (!IsRunning)
                 return false;
             var packet = NetPacket.CreateRawPacket(PacketProperty.UnconnectedMessage, message, start, length);
-            return SendRaw(packet, remoteEndPoint);
+            bool result = SendRaw(packet, remoteEndPoint);
+            NetPacket.RecycleRawPacket(packet);
+            return result;
         }
 
         public bool SendDiscoveryRequest(NetDataWriter writer, int port)
@@ -843,7 +846,9 @@ namespace LiteNetLib
             if (!IsRunning)
                 return false;
             var packet = NetPacket.CreateRawPacket(PacketProperty.DiscoveryRequest, data, start, length);
-            return _socket.SendBroadcast(packet, 0, packet.Length, port);
+            bool result = _socket.SendBroadcast(packet, 0, packet.Length, port);
+            NetPacket.RecycleRawPacket(packet);
+            return result;
         }
 
         public bool SendDiscoveryResponse(NetDataWriter writer, NetEndPoint remoteEndPoint)
@@ -861,7 +866,9 @@ namespace LiteNetLib
             if (!IsRunning)
                 return false;
             var packet = NetPacket.CreateRawPacket(PacketProperty.DiscoveryResponse, data, start, length);
-            return SendRaw(packet, remoteEndPoint);
+            bool result = SendRaw(packet, remoteEndPoint);
+            NetPacket.RecycleRawPacket(packet);
+            return result;
         }
 
         /// <summary>
@@ -933,6 +940,7 @@ namespace LiteNetLib
                     var disconnectPacket = NetPacket.CreateRawPacket(PacketProperty.Disconnect, 8);
                     FastBitConverter.GetBytes(disconnectPacket, 1, netPeer.ConnectId);
                     SendRaw(disconnectPacket, netPeer.EndPoint);
+                    NetPacket.RecycleRawPacket(disconnectPacket);
                 }
 
             //Clear

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -37,7 +37,7 @@ namespace LiteNetLib
         private DateTime _lastPacketReceivedStart;
 
         //Common            
-        private readonly Stack<NetPacket> _packetPool;
+        private static readonly Pool<NetPacket> PacketPool = new Pool<NetPacket>();
         private readonly NetEndPoint _remoteEndPoint;
         private readonly NetManager _peerListener;
 
@@ -144,7 +144,6 @@ namespace LiteNetLib
             _sequencedChannel = new SequencedChannel(this);
             _simpleChannel = new SimpleChannel(this);
 
-            _packetPool = new Stack<NetPacket>();
             _holdedFragments = new Dictionary<ushort, IncomingFragments>();
 
             _mergeData.Init(PacketProperty.Merged, NetConstants.PossibleMtu[NetConstants.PossibleMtu.Length - 1]);
@@ -181,6 +180,7 @@ namespace LiteNetLib
 
             //Send raw
             _peerListener.SendRaw(connectPacket, _remoteEndPoint);
+            NetPacket.RecycleRawPacket(connectPacket);
         }
 
         private void SendConnectAccept()
@@ -196,6 +196,7 @@ namespace LiteNetLib
 
             //Send raw
             _peerListener.SendRaw(connectPacket, _remoteEndPoint);
+            NetPacket.RecycleRawPacket(connectPacket);
         }
 
         internal bool ProcessConnectAccept(NetPacket packet)
@@ -409,17 +410,7 @@ namespace LiteNetLib
         internal NetPacket GetPacketFromPool(PacketProperty property = PacketProperty.Unreliable, int size=0, bool init=true)
         {
             NetPacket packet = null;
-            lock (_packetPool)
-            {
-                if (_packetPool.Count > 0)
-                {
-                    packet = _packetPool.Pop();
-                }
-            }
-            if(packet == null)
-            {
-                packet = new NetPacket();
-            }
+            packet = PacketPool.Get();
             if(init)
                 packet.Init(property, size);
             return packet;
@@ -427,11 +418,8 @@ namespace LiteNetLib
 
         internal void Recycle(NetPacket packet)
         {
-            packet.RawData = null;
-            lock (_packetPool)
-            {
-                _packetPool.Push(packet);
-            }
+            packet.Recycle();
+            PacketPool.Recycle(packet);
         }
 
         internal void AddIncomingPacket(NetPacket p)

--- a/LiteNetLib/Utils/Pool.cs
+++ b/LiteNetLib/Utils/Pool.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LiteNetLib.Utils
+{
+    public class Pool<T> where T:class, new()
+    {
+        private readonly Stack<T> _pool;
+
+        public Pool()
+        {
+            _pool = new Stack<T>();
+        }
+
+        public T Get()
+        {
+            T element = null;
+            lock (_pool)
+            {
+                if (_pool.Count > 0)
+                {
+                    element = _pool.Pop();
+                }
+            }
+            if (element == null)
+            {
+                element = new T();
+            }
+            return element;
+        }
+
+        public void Recycle(T element)
+        {
+            lock (_pool)
+            {
+                _pool.Push(element);
+            }
+        }
+    }
+
+    public class PoolArray<T>
+    {
+        private readonly Dictionary<int, Stack<T[]>> _pool;
+
+        public PoolArray()
+        {
+            _pool = new Dictionary<int, Stack<T[]>>();
+        }
+
+        public T[] Get(int arrayLength)
+        {
+            T[] array = null;
+            lock (_pool)
+            {
+                Stack<T[]> stack;
+                if (_pool.TryGetValue(arrayLength, out stack))
+                {
+                    if (stack.Count > 0)
+                    {
+                        array = stack.Pop();
+                    }
+                }
+            }
+            if (array == null)
+            {
+                array = new T[arrayLength];
+            }
+            return array;
+        }
+
+        public void Recycle(T[] element)
+        {
+            Array.Clear(element, 0, element.Length);
+            lock (_pool)
+            {
+                Stack<T[]> stack;
+                if (!_pool.TryGetValue(element.Length, out stack))
+                {
+                    stack = new Stack<T[]>();
+                    _pool.Add(element.Length, stack);
+                }
+                stack.Push(element);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I am using LiteNetLib with Unity and the profiler was showing some bits on GC Alloc when sending messages.

By iterating lists instead of dictionaries and pooling byte arrays I was able to remove a lot of it. It is now 0 for the method SendToAll, that was being called nearly every frame.

To do it I used a pool that resembles the NetPacket pool that was implemented with an Stack and tracked all the `new byte[]` that I was able to find to also use a pool and recycle them before they were deferenced.

Thank you for this library, the code is clean and it works without problems.