### PR TITLE
NetPeer Connection Fix #102

### DIFF
--- a/LiteNetLib/NetConstants.cs
+++ b/LiteNetLib/NetConstants.cs
@@ -53,6 +53,8 @@ namespace LiteNetLib
         internal const int ProtocolId = 1;
         internal const int MaxUdpHeaderSize = 68;
         internal const int PacketSizeLimit = ushort.MaxValue - MaxUdpHeaderSize;
+        internal const int RequestConnectIdIndex = 5;
+        internal const int AcceptConnectIdIndex = 1;
 
         internal static readonly int[] PossibleMtu =
         {

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -214,7 +214,7 @@ namespace LiteNetLib
 
             //Add data
             FastBitConverter.GetBytes(connectPacket.RawData, 1, NetConstants.ProtocolId);
-            FastBitConverter.GetBytes(connectPacket.RawData, 5, _connectId);
+            FastBitConverter.GetBytes(connectPacket.RawData, NetConstants.RequestConnectIdIndex, _connectId);
             Buffer.BlockCopy(keyData, 0, connectPacket.RawData, 13, keyData.Length);
 
             //Send raw
@@ -230,7 +230,7 @@ namespace LiteNetLib
             var connectPacket = _packetPool.Get(PacketProperty.ConnectAccept, 8);
 
             //Add data
-            FastBitConverter.GetBytes(connectPacket.RawData, 1, _connectId);
+            FastBitConverter.GetBytes(connectPacket.RawData, NetConstants.AcceptConnectIdIndex, _connectId);
 
             //Send raw
             _peerListener.SendRawAndRecycle(connectPacket, _remoteEndPoint);
@@ -242,7 +242,7 @@ namespace LiteNetLib
                 return false;
 
             //check connection id
-            if (BitConverter.ToInt64(packet.RawData, 1) != _connectId)
+            if (BitConverter.ToInt64(packet.RawData, NetConstants.AcceptConnectIdIndex) != _connectId)
             {
                 return false;
             }
@@ -586,7 +586,7 @@ namespace LiteNetLib
             {
                 case PacketProperty.ConnectRequest:
                     //response with connect
-                    long newId = BitConverter.ToInt64(packet.RawData, 1);
+                    long newId = BitConverter.ToInt64(packet.RawData, NetConstants.RequestConnectIdIndex);
                     if (newId > _connectId)
                     {
                         _connectId = newId;


### PR DESCRIPTION
#102 near the end references an edge case where both clients are trying to connect to each other in v0.7.5,  First connect would succeed if one person is faster.  If they arrive near the same time, the ConnId would be incorrect due to SendConnectRequest() and handle ConnectRequest() indexes are incorrect.  

Added Two new Buffer Indexes in NetConstants.  One for ConnectRequest and one for ConnectAccept, since ConnectAccept uses index 1 (no ProtocolId) and ConnectRequest uses index 5.