### PR TITLE
Fix divide by zero error in NetStatistics

### DIFF
--- a/LiteNetLib/NetStatistics.cs
+++ b/LiteNetLib/NetStatistics.cs
@@ -7,8 +7,19 @@
         public ulong BytesSent;
         public ulong BytesReceived;
         public ulong PacketLoss;
-        public ulong PacketLossPercent { get { return PacketLoss * 100 / PacketsSent; } }
-        
+        public ulong PacketLossPercent
+        {
+            get
+            {
+                if (PacketsSent == 0)
+                {
+                    return 0;
+                }
+
+                return PacketLoss * 100 / PacketsSent;
+            }
+        }
+
         public override string ToString()
         {
             return


### PR DESCRIPTION
Hey! I found a simple divide by zero error in the `NetStatistics` class. I've added a check for making sure that the number of packets isn't 0 (and if it is, just return 0).