### PR TITLE
Added GetTypeName function to NetPacketProcessor to prevent InvalidCastException

### DIFF
--- a/LiteNetLib/Utils/NetPacketProcessor.cs
+++ b/LiteNetLib/Utils/NetPacketProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LiteNetLib.Utils
 {
@@ -15,7 +16,7 @@ namespace LiteNetLib.Utils
         protected virtual ulong GetHash(Type type)
         {
             ulong hash;
-            string typeName = type.Name;
+            string typeName = GetTypeName(type);
             if (_hashCache.TryGetValue(typeName, out hash))
             {
                 return hash;
@@ -45,6 +46,15 @@ namespace LiteNetLib.Utils
         protected virtual void WriteHash(Type type, NetDataWriter writer)
         {
             writer.Put(GetHash(type));
+        }
+
+        public static string GetTypeName(Type t)
+        {
+            if (!t.IsGenericType) return t.Name;
+
+            var genericTypes = t.GetGenericArguments();
+            var genericArguments = genericTypes.Aggregate("", (current, type) => current + type.Name);
+            return t.Name + genericArguments;
         }
 
         /// <summary>

--- a/LiteNetLib/Utils/NetSerializer.cs
+++ b/LiteNetLib/Utils/NetSerializer.cs
@@ -178,7 +178,7 @@ namespace LiteNetLib.Utils
         {
             Type t = typeof(T);
             StructInfo info;
-            if (_registeredTypes.TryGetValue(t.Name, out info))
+            if (_registeredTypes.TryGetValue(NetPacketProcessor.GetTypeName(t), out info))
             {
                 return info;
             }
@@ -240,7 +240,7 @@ namespace LiteNetLib.Utils
                     }
                     else
                     {
-                        throw new Exception("Not supported enum underlying type: " + underlyingType.Name);
+                        throw new Exception("Not supported enum underlying type: " +NetPacketProcessor.GetTypeName(underlyingType));
                     }
                 }
                 else if (propertyType == typeof(string))
@@ -470,11 +470,11 @@ namespace LiteNetLib.Utils
                     }
                     else
                     {
-                        throw new Exception("Unknown property type: " + propertyType.Name);
+                        throw new Exception("Unknown property type: " +NetPacketProcessor.GetTypeName(propertyType));
                     }
                 }
             }
-            _registeredTypes.Add(t.Name, info);
+            _registeredTypes.Add(NetPacketProcessor.GetTypeName(t), info);
 
             return info;
         }


### PR DESCRIPTION
When we use a class that has a generic property inside, an invalid cast exception happens when reading packets. That's because type.Name doesn't count generic parameters. for example, if we have this class:
`public class Packet<T>
{
public T Value{get;set;}
}`
Hash function will generate the same hash for these 2 instances:
`var integerPacket = new Packet<int>{Value = 2};`
`var stringPacket = new Packet<string>{Value = "abc"};`
and this causes invalid cast exception on the listener side. 

I added a function that adds generic arguments after the type's name to avoid this.