### PR TITLE
NetManager.cs PeerList instead of function

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -64,7 +64,7 @@ namespace LiteNetLib
         private readonly NetPeerCollection _peers;
         private readonly HashSet<NetEndPoint> _connectingPeers;
         private readonly int _maxConnections;
-        private List<Peer> _peerList;
+        private List<NetPeer> _peerList;
 
         internal readonly NetPacketPool NetPacketPool;
 
@@ -176,7 +176,7 @@ namespace LiteNetLib
             get { return _socket.LocalPort; }
         }
         
-        public List<Peer> PeerList
+        public List<NetPeer> PeerList
         {
             get
             {
@@ -193,11 +193,6 @@ namespace LiteNetLib
                 }
                 return _peerList;
             }
-        }
-
-        public int PeersCount
-        {
-            get { return _peers.Count; }
         }
 
         /// <summary>

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -64,7 +64,7 @@ namespace LiteNetLib
         private readonly NetPeerCollection _peers;
         private readonly HashSet<NetEndPoint> _connectingPeers;
         private readonly int _maxConnections;
-        private List<NetPeer> _peerList;
+        private List<NetPeer> _connectedPeerList;
 
         internal readonly NetPacketPool NetPacketPool;
 
@@ -180,18 +180,18 @@ namespace LiteNetLib
         {
             get
             {
-                _peerList.Clear();
+                _connectedPeerList.Clear();
                 lock (_peers)
                 {
                     for(int i = 0; i < _peers.Count; i++)
                     {
                         if ((_peers[i].ConnectionState & ConnectionState.Connected) != 0)
                         {
-                            _peerList.Add(_peers[i]);
+                            _connectedPeerList.Add(_peers[i]);
                         }
                     }
                 }
-                return _peerList;
+                return _connectedPeerList;
             }
         }
         
@@ -206,7 +206,7 @@ namespace LiteNetLib
         /// <param name="listener">Network events listener</param>
         public NetManager(INetEventListener listener) : this(listener, 1)
         {
-            
+            _connectedPeerList = new List<NetPeer>();
         }
 
         /// <summary>
@@ -227,6 +227,7 @@ namespace LiteNetLib
             _peers = new NetPeerCollection(maxConnections);
             _connectingPeers = new HashSet<NetEndPoint>();
             _maxConnections = maxConnections;
+            _connectedPeerList = new List<NetPeer>();
         }
 
         internal void ConnectionLatencyUpdated(NetPeer fromPeer, int latency)

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -185,7 +185,7 @@ namespace LiteNetLib
                 {
                     for(int i = 0; i < _peers.Count; i++)
                     {
-                        if ((_peers[i].ConnectionState & peerState) != 0)
+                        if ((_peers[i].ConnectionState & ConnectionState.Connected) != 0)
                         {
                             _peerList.Add(_peers[i]);
                         }

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -176,7 +176,7 @@ namespace LiteNetLib
             get { return _socket.LocalPort; }
         }
         
-        public List<NetPeer> PeerList
+        public List<NetPeer> ConnectedPeerList
         {
             get
             {
@@ -193,6 +193,11 @@ namespace LiteNetLib
                 }
                 return _peerList;
             }
+        }
+        
+        public int PeersCount
+        {
+            get { return _peers.Count; }
         }
 
         /// <summary>

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -64,6 +64,7 @@ namespace LiteNetLib
         private readonly NetPeerCollection _peers;
         private readonly HashSet<NetEndPoint> _connectingPeers;
         private readonly int _maxConnections;
+        private List<Peer> _peerList;
 
         internal readonly NetPacketPool NetPacketPool;
 
@@ -173,6 +174,25 @@ namespace LiteNetLib
         public int LocalPort
         {
             get { return _socket.LocalPort; }
+        }
+        
+        public List<Peer> PeerList
+        {
+            get
+            {
+                _peerList.Clear();
+                lock (_peers)
+                {
+                    for(int i = 0; i < _peers.Count; i++)
+                    {
+                        if ((_peers[i].ConnectionState & peerState) != 0)
+                        {
+                            _peerList.Add(_peers[i]);
+                        }
+                    }
+                }
+                return _peerList;
+            }
         }
 
         public int PeersCount

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -206,7 +206,7 @@ namespace LiteNetLib
         /// <param name="listener">Network events listener</param>
         public NetManager(INetEventListener listener) : this(listener, 1)
         {
-            _connectedPeerList = new List<NetPeer>();
+            
         }
 
         /// <summary>


### PR DESCRIPTION
Based on GetPeersNonAlloc, this property is really useful and avoids creating Lists in different classes. It is also more human readable.