### PR TITLE
serializer now can serialize boxed types

### DIFF
--- a/LiteNetLib.Test/NetSerializerTest.cs
+++ b/LiteNetLib.Test/NetSerializerTest.cs
@@ -210,5 +210,69 @@ namespace LiteNetLib.Test
             Assert.AreEqual(readPackage.Sample2, sPacket.Sample2);
             Assert.AreEqual(readPackage.Sample3, sPacket.Sample3);
         }
+
+        [Test]
+        [Timeout(2000)]
+        public void ObjectPacket1NullTest()
+        {
+            var sPacket = new ObjectPropertyPacket1
+            {
+                Sample1 = "EFG",
+                Sample2 = "XYZ"
+            };
+
+
+            var writer = new NetDataWriter();
+            _packetProcessor.Write(writer, sPacket);
+
+            var reader = new NetDataReader(writer.CopyData());
+            ObjectPropertyPacket1 readPackage = null;
+
+            _packetProcessor.SubscribeReusable<ObjectPropertyPacket1>(
+                packet =>
+                {
+                    readPackage = packet;
+                });
+
+            _packetProcessor.ReadAllPackets(reader);
+
+            Assert.NotNull(readPackage);
+            Assert.AreEqual(readPackage.Prop, sPacket.Prop);
+            Assert.AreEqual(readPackage.Sample1, sPacket.Sample1);
+            Assert.AreEqual(readPackage.Sample2, sPacket.Sample2);
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void ObjectPacket2NullTest()
+        {
+            var sPacket = new ObjectPropertyPacket2
+            {
+                Sample1 = "AHJ",
+                Sample2 = 4,
+                Sample3 = "6"
+            };
+
+
+            var writer = new NetDataWriter();
+            _packetProcessor.Write(writer, sPacket);
+
+            var reader = new NetDataReader(writer.CopyData());
+            ObjectPropertyPacket2 readPackage = null;
+
+            _packetProcessor.SubscribeReusable<ObjectPropertyPacket2>(
+                packet =>
+                {
+                    readPackage = packet;
+                });
+
+            _packetProcessor.ReadAllPackets(reader);
+
+            Assert.NotNull(readPackage);
+            Assert.AreEqual(readPackage.Prop, sPacket.Prop);
+            Assert.AreEqual(readPackage.Sample1, sPacket.Sample1);
+            Assert.AreEqual(readPackage.Sample2, sPacket.Sample2);
+            Assert.AreEqual(readPackage.Sample3, sPacket.Sample3);
+        }
     }
 }

--- a/LiteNetLib.Test/NetSerializerTest.cs
+++ b/LiteNetLib.Test/NetSerializerTest.cs
@@ -13,13 +13,13 @@ namespace LiteNetLib.Test
             _samplePacket = new SamplePacket
             {
                 SomeFloat = 3.42f,
-                SomeIntArray = new[] {6, 5, 4},
+                SomeIntArray = new[] { 6, 5, 4 },
                 SomeString = "Test String",
                 SomeVector2 = new SomeVector2(4, 5),
-                SomeVectors = new[] {new SomeVector2(1, 2), new SomeVector2(3, 4)},
+                SomeVectors = new[] { new SomeVector2(1, 2), new SomeVector2(3, 4) },
                 SomeEnum = TestEnum.B,
                 SomeByteArray = new byte[] { 255, 1, 0 },
-                TestObj = new SampleNetSerializable {Value = 5}
+                TestObj = new SampleNetSerializable { Value = 5 }
             };
 
             _packetProcessor = new NetPacketProcessor();
@@ -91,6 +91,16 @@ namespace LiteNetLib.Test
             public SampleNetSerializable TestObj { get; set; }
         }
 
+        private class ObjectPropertyPacket1
+        {
+            public object Prop { get; set; }
+        }
+
+        private class ObjectPropertyPacket2
+        {
+            public object[] Prop { get; set; }
+        }
+
         private static bool AreSame(string s1, string s2)
         {
             if (string.IsNullOrEmpty(s1) && string.IsNullOrEmpty(s2))
@@ -128,6 +138,52 @@ namespace LiteNetLib.Test
             Assert.AreEqual(_samplePacket.SomeEnum, readPackage.SomeEnum);
             Assert.AreEqual(_samplePacket.TestObj.Value, readPackage.TestObj.Value);
             Assert.AreEqual(_samplePacket.SomeByteArray, readPackage.SomeByteArray);
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void ObjectPacket1Test()
+        {
+            var sPacket = new ObjectPropertyPacket1() { Prop = "Abc" };
+            var writer = new NetDataWriter();
+            _packetProcessor.Write(writer, sPacket);
+
+            var reader = new NetDataReader(writer.CopyData());
+            ObjectPropertyPacket1 readPackage = null;
+
+            _packetProcessor.SubscribeReusable<ObjectPropertyPacket1>(
+                packet =>
+                {
+                    readPackage = packet;
+                });
+
+            _packetProcessor.ReadAllPackets(reader);
+
+            Assert.NotNull(readPackage);
+            Assert.AreEqual(readPackage.Prop, sPacket.Prop);
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void ObjectPacket2Test()
+        {
+            var sPacket = new ObjectPropertyPacket2() { Prop = new object[] { "Abc", 2, false } };
+            var writer = new NetDataWriter();
+            _packetProcessor.Write(writer, sPacket);
+
+            var reader = new NetDataReader(writer.CopyData());
+            ObjectPropertyPacket2 readPackage = null;
+
+            _packetProcessor.SubscribeReusable<ObjectPropertyPacket2>(
+                packet =>
+                {
+                    readPackage = packet;
+                });
+
+            _packetProcessor.ReadAllPackets(reader);
+
+            Assert.NotNull(readPackage);
+            Assert.AreEqual(readPackage.Prop, sPacket.Prop);
         }
     }
 }

--- a/LiteNetLib.Test/NetSerializerTest.cs
+++ b/LiteNetLib.Test/NetSerializerTest.cs
@@ -93,12 +93,17 @@ namespace LiteNetLib.Test
 
         private class ObjectPropertyPacket1
         {
+            public string Sample1 { get;set;}
             public object Prop { get; set; }
+            public string Sample2 { get; set; }
         }
 
         private class ObjectPropertyPacket2
         {
+            public string Sample1 { get; set; }
+            public int Sample2 { get; set; }
             public object[] Prop { get; set; }
+            public string Sample3 { get; set; }
         }
 
         private static bool AreSame(string s1, string s2)
@@ -144,7 +149,14 @@ namespace LiteNetLib.Test
         [Timeout(2000)]
         public void ObjectPacket1Test()
         {
-            var sPacket = new ObjectPropertyPacket1() { Prop = "Abc" };
+            var sPacket = new ObjectPropertyPacket1
+            {
+                Sample1 = "EFG",
+                Prop = "Abc",
+                Sample2 = "XYZ"
+            };
+
+
             var writer = new NetDataWriter();
             _packetProcessor.Write(writer, sPacket);
 
@@ -161,13 +173,23 @@ namespace LiteNetLib.Test
 
             Assert.NotNull(readPackage);
             Assert.AreEqual(readPackage.Prop, sPacket.Prop);
+            Assert.AreEqual(readPackage.Sample1, sPacket.Sample1);
+            Assert.AreEqual(readPackage.Sample2, sPacket.Sample2);
         }
 
         [Test]
         [Timeout(2000)]
         public void ObjectPacket2Test()
         {
-            var sPacket = new ObjectPropertyPacket2() { Prop = new object[] { "Abc", 2, false } };
+            var sPacket = new ObjectPropertyPacket2
+            {
+                Sample1 = "AHJ",
+                Sample2 = 4,
+                Sample3 = "6",
+                Prop = new object[] { "Abc", 2, false }
+            };
+
+
             var writer = new NetDataWriter();
             _packetProcessor.Write(writer, sPacket);
 
@@ -184,6 +206,9 @@ namespace LiteNetLib.Test
 
             Assert.NotNull(readPackage);
             Assert.AreEqual(readPackage.Prop, sPacket.Prop);
+            Assert.AreEqual(readPackage.Sample1, sPacket.Sample1);
+            Assert.AreEqual(readPackage.Sample2, sPacket.Sample2);
+            Assert.AreEqual(readPackage.Sample3, sPacket.Sample3);
         }
     }
 }

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -313,7 +313,7 @@ namespace LiteNetLib.Utils
         public string GetString(int maxLength)
         {
             int bytesCount = GetInt();
-            if (bytesCount <= 0 || bytesCount > maxLength*2)
+            if (bytesCount <= 0 || bytesCount > maxLength * 2)
             {
                 return string.Empty;
             }
@@ -340,6 +340,82 @@ namespace LiteNetLib.Utils
             string result = Encoding.UTF8.GetString(_data, _position, bytesCount);
             _position += bytesCount;
             return result;
+        }
+
+        public object GetObject()
+        {
+            var type = Type.GetType(GetString());
+
+            if (type == typeof(byte))
+                return GetByte();
+
+            if (type == typeof(sbyte))
+                return GetSByte();
+
+            if (type == typeof(bool[]))
+                return GetBoolArray();
+
+            if (type == typeof(ushort[]))
+                return GetUShortArray();
+
+            if (type == typeof(short[]))
+                return GetShortArray();
+
+            if (type == typeof(long[]))
+                return GetLongArray();
+
+            if (type == typeof(ulong[]))
+                return GetULongArray();
+
+            if (type == typeof(int[]))
+                return GetIntArray();
+
+            if (type == typeof(uint[]))
+                return GetUIntArray();
+
+            if (type == typeof(float[]))
+                return GetFloatArray();
+
+            if (type == typeof(double[]))
+                return GetDoubleArray();
+
+            if (type == typeof(string[]))
+                return GetStringArray();
+
+            if (type == typeof(bool))
+                return GetBool();
+
+            if (type == typeof(char))
+                return GetBool();
+
+            if (type == typeof(ushort))
+                return GetUShort();
+
+            if (type == typeof(short))
+                return GetShort();
+
+            if (type == typeof(long))
+                return GetLong();
+
+            if (type == typeof(ulong))
+                return GetULong();
+
+            if (type == typeof(int))
+                return GetInt();
+
+            if (type == typeof(uint))
+                return GetUInt();
+
+            if (type == typeof(float))
+                return GetFloat();
+
+            if (type == typeof(double))
+                return GetDouble();
+
+            if (type == typeof(string))
+                return GetString();
+
+            throw new InvalidTypeException("The object type is not supported");
         }
 
         public byte[] GetRemainingBytes()

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -342,7 +342,7 @@ namespace LiteNetLib.Utils
             return result;
         }
 
-        public object GetObject()
+        public object GetSimpleObject()
         {
             var typeString = GetString();
             if(typeString == "null")
@@ -422,7 +422,7 @@ namespace LiteNetLib.Utils
             throw new InvalidTypeException("The object type is not supported");
         }
 
-        public object[] GetObjectArray()
+        public object[] GetSimpleObjectArray()
         {
             var count = GetInt();
             
@@ -432,7 +432,7 @@ namespace LiteNetLib.Utils
             var array = new object[count];
             for (int i = 0; i < array.Length; i++)
             {
-                array[i] = GetObject();
+                array[i] = GetSimpleObject();
             }
 
             return array;

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -418,6 +418,17 @@ namespace LiteNetLib.Utils
             throw new InvalidTypeException("The object type is not supported");
         }
 
+        public object[] GetObjectArray()
+        {
+            var count = GetInt();
+            var array = new object[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = GetObject();
+            }
+            return array;
+        }
+
         public byte[] GetRemainingBytes()
         {
             byte[] outgoingData = new byte[AvailableBytes];

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -344,7 +344,11 @@ namespace LiteNetLib.Utils
 
         public object GetObject()
         {
-            var type = Type.GetType(GetString());
+            var typeString = GetString();
+            if(typeString == "null")
+                return null;
+
+            var type = Type.GetType(typeString);
 
             if (type == typeof(byte))
                 return GetByte();
@@ -421,11 +425,16 @@ namespace LiteNetLib.Utils
         public object[] GetObjectArray()
         {
             var count = GetInt();
+            
+            if(count == -1)
+                return null;
+
             var array = new object[count];
             for (int i = 0; i < array.Length; i++)
             {
                 array[i] = GetObject();
             }
+
             return array;
         }
 

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -50,7 +50,7 @@ namespace LiteNetLib.Utils
                 netDataWriter.Put(bytes);
                 return netDataWriter;
             }
-            return new NetDataWriter(true, 0) {_data = bytes};
+            return new NetDataWriter(true, 0) { _data = bytes };
         }
 
         /// <summary>
@@ -417,6 +417,95 @@ namespace LiteNetLib.Utils
             Encoding.UTF8.GetBytes(value, 0, length, _data, _position);
 
             _position += bytesCount;
+        }
+
+        public void PutObject(object obj)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(nameof(obj));
+
+            var type = obj.GetType().ToString();
+
+            // put the type before the actual object so NetDataReader can deserialize
+            Put(type);
+
+            switch (obj)
+            {
+                case float variable:
+                    Put(variable);
+                    break;
+                case double variable:
+                    Put(variable);
+                    break;
+                case long variable:
+                    Put(variable);
+                    break;
+                case ulong variable:
+                    Put(variable);
+                    break;
+                case int variable:
+                    Put(variable);
+                    break;
+                case uint variable:
+                    Put(variable);
+                    break;
+                case char variable:
+                    Put(variable);
+                    break;
+                case ushort variable:
+                    Put(variable);
+                    break;
+                case short variable:
+                    Put(variable);
+                    break;
+                case sbyte variable:
+                    Put(variable);
+                    break;
+                case byte variable:
+                    Put(variable);
+                    break;
+                case bool variable:
+                    Put(variable);
+                    break;
+                case string variable:
+                    Put(variable);
+                    break;
+                case byte[] variable:
+                    PutBytesWithLength(variable);
+                    break;
+                case float[] variable:
+                    PutArray(variable);
+                    break;
+                case double[] variable:
+                    PutArray(variable);
+                    break;
+                case long[] variable:
+                    PutArray(variable);
+                    break;
+                case ulong[] variable:
+                    PutArray(variable);
+                    break;
+                case int[] variable:
+                    PutArray(variable);
+                    break;
+                case uint[] variable:
+                    PutArray(variable);
+                    break;
+                case ushort[] variable:
+                    PutArray(variable);
+                    break;
+                case short[] variable:
+                    PutArray(variable);
+                    break;
+                case bool[] variable:
+                    PutArray(variable);
+                    break;
+                case string[] variable:
+                    PutArray(variable);
+                    break;
+                default:
+                    throw new InvalidTypeException("The object type is not supported");
+            }
         }
     }
 }

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -507,5 +507,12 @@ namespace LiteNetLib.Utils
                     throw new InvalidTypeException("The object type is not supported");
             }
         }
+
+        public void PutObjectArray(object[] value)
+        {
+            Put(value.Length);
+            foreach (var v in value)
+                PutObject(v);
+        }
     }
 }

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -419,7 +419,7 @@ namespace LiteNetLib.Utils
             _position += bytesCount;
         }
 
-        public void PutObject(object obj)
+        public void PutSimpleObject(object obj)
         {
             if (obj == null)
             {
@@ -559,7 +559,7 @@ namespace LiteNetLib.Utils
             }
         }
 
-        public void PutObjectArray(object[] value)
+        public void PutSimpleObjectArray(object[] value)
         {
             if (value == null)
             {
@@ -569,7 +569,7 @@ namespace LiteNetLib.Utils
 
             Put(value.Length);
             foreach (var v in value)
-                PutObject(v);
+                PutSimpleObject(v);
         }
     }
 }

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -422,7 +422,10 @@ namespace LiteNetLib.Utils
         public void PutObject(object obj)
         {
             if (obj == null)
-                throw new ArgumentNullException("obj");
+            {
+                Put("null");
+                return;
+            }
 
             var type = obj.GetType().ToString();
 
@@ -558,6 +561,12 @@ namespace LiteNetLib.Utils
 
         public void PutObjectArray(object[] value)
         {
+            if (value == null)
+            {
+                Put(-1);
+                return;
+            }
+
             Put(value.Length);
             foreach (var v in value)
                 PutObject(v);

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -422,89 +422,137 @@ namespace LiteNetLib.Utils
         public void PutObject(object obj)
         {
             if (obj == null)
-                throw new ArgumentNullException(nameof(obj));
+                throw new ArgumentNullException("obj");
 
             var type = obj.GetType().ToString();
 
             // put the type before the actual object so NetDataReader can deserialize
             Put(type);
 
-            switch (obj)
+
+            if (obj is float)
             {
-                case float variable:
-                    Put(variable);
-                    break;
-                case double variable:
-                    Put(variable);
-                    break;
-                case long variable:
-                    Put(variable);
-                    break;
-                case ulong variable:
-                    Put(variable);
-                    break;
-                case int variable:
-                    Put(variable);
-                    break;
-                case uint variable:
-                    Put(variable);
-                    break;
-                case char variable:
-                    Put(variable);
-                    break;
-                case ushort variable:
-                    Put(variable);
-                    break;
-                case short variable:
-                    Put(variable);
-                    break;
-                case sbyte variable:
-                    Put(variable);
-                    break;
-                case byte variable:
-                    Put(variable);
-                    break;
-                case bool variable:
-                    Put(variable);
-                    break;
-                case string variable:
-                    Put(variable);
-                    break;
-                case byte[] variable:
-                    PutBytesWithLength(variable);
-                    break;
-                case float[] variable:
-                    PutArray(variable);
-                    break;
-                case double[] variable:
-                    PutArray(variable);
-                    break;
-                case long[] variable:
-                    PutArray(variable);
-                    break;
-                case ulong[] variable:
-                    PutArray(variable);
-                    break;
-                case int[] variable:
-                    PutArray(variable);
-                    break;
-                case uint[] variable:
-                    PutArray(variable);
-                    break;
-                case ushort[] variable:
-                    PutArray(variable);
-                    break;
-                case short[] variable:
-                    PutArray(variable);
-                    break;
-                case bool[] variable:
-                    PutArray(variable);
-                    break;
-                case string[] variable:
-                    PutArray(variable);
-                    break;
-                default:
-                    throw new InvalidTypeException("The object type is not supported");
+                var variable = (float) obj;
+                Put(variable);
+            }
+            else if (obj is double)
+            {
+                var variable = (double)obj;
+                Put(variable);
+            }
+            else if (obj is long)
+            {
+                var variable = (long)obj;
+                Put(variable);
+            }
+            else if (obj is ulong)
+            {
+                var variable = (ulong)obj;
+                Put(variable);
+            }
+            else if (obj is int)
+            {
+                var variable = (int)obj;
+                Put(variable);
+            }
+            else if (obj is uint)
+            {
+                var variable = (uint)obj;
+                Put(variable);
+            }
+            else if (obj is char)
+            {
+                var variable = (char)obj;
+                Put(variable);
+            }
+            else if (obj is ushort)
+            {
+                var variable = (ushort)obj;
+                Put(variable);
+            }
+            else if (obj is short)
+            {
+                var variable = (short)obj;
+                Put(variable);
+            }
+            else if (obj is sbyte)
+            {
+                var variable = (sbyte)obj;
+                Put(variable);
+            }
+            else if (obj is byte)
+            {
+                var variable = (byte)obj;
+                Put(variable);
+            }
+            else if (obj is bool)
+            {
+                var variable = (bool)obj;
+                Put(variable);
+            }
+            else if (obj is string)
+            {
+                var variable = (string)obj;
+                Put(variable);
+            }
+            else if (obj is byte[])
+            {
+                var variable = (byte[])obj;
+                PutBytesWithLength(variable);
+            }
+            else if (obj is float[])
+            {
+                var variable = (float[])obj;
+                PutArray(variable);
+            }
+            else if (obj is double[])
+            {
+                var variable = (double[])obj;
+                PutArray(variable);
+            }
+            else if (obj is long[])
+            {
+                var variable = (long[])obj;
+                PutArray(variable);
+            }
+            else if (obj is ulong[])
+            {
+                var variable = (ulong[])obj;
+                PutArray(variable);
+            }
+            else if (obj is int[])
+            {
+                var variable = (int[])obj;
+                PutArray(variable);
+            }
+            else if (obj is uint[] )
+            {
+                var variable = (uint[])obj;
+                PutArray(variable);
+            }
+            else if (obj is ushort[])
+            {
+                var variable = (ushort[])obj;
+                PutArray(variable);
+            }
+            else if (obj is short[])
+            {
+                var variable = (short[])obj;
+                PutArray(variable);
+            }
+            else if (obj is bool[])
+            {
+                var variable = (bool[])obj;
+                PutArray(variable);
+            }
+            else if (obj is string[])
+            {
+                var variable = (string[])obj;
+                PutArray(variable);
+            }
+            else
+            {
+                throw new InvalidTypeException("The object type is not supported");
             }
         }
 

--- a/LiteNetLib/Utils/NetPacketProcessor.cs
+++ b/LiteNetLib/Utils/NetPacketProcessor.cs
@@ -5,11 +5,11 @@ namespace LiteNetLib.Utils
 {
     public class NetPacketProcessor
     {
-        protected delegate void SubscrieDelegate(NetDataReader reader, object userData);
+        protected delegate void SubscribeDelegate(NetDataReader reader, object userData);
         private readonly Dictionary<string, ulong> _hashCache = new Dictionary<string, ulong>();
         private readonly char[] _hashBuffer = new char[1024];
         private readonly NetSerializer _netSerializer = new NetSerializer();
-        private readonly Dictionary<ulong, SubscrieDelegate> _callbacks = new Dictionary<ulong, SubscrieDelegate>();
+        private readonly Dictionary<ulong, SubscribeDelegate> _callbacks = new Dictionary<ulong, SubscribeDelegate>();
         private readonly NetDataWriter _netDataWriter = new NetDataWriter();
 
         protected virtual ulong GetHash(Type type)
@@ -31,10 +31,10 @@ namespace LiteNetLib.Utils
             return hash;
         }
 
-        protected virtual SubscrieDelegate GetCallbackFromData(NetDataReader reader)
+        protected virtual SubscribeDelegate GetCallbackFromData(NetDataReader reader)
         {
             var hash = reader.GetULong();
-            SubscrieDelegate action;
+            SubscribeDelegate action;
             if (!_callbacks.TryGetValue(hash, out action))
             {
                 throw new ParseException("Undefined packet in NetDataReader");

--- a/LiteNetLib/Utils/NetSerializer.cs
+++ b/LiteNetLib/Utils/NetSerializer.cs
@@ -473,10 +473,20 @@ namespace LiteNetLib.Utils
                     {
                         if (propertyType == typeof(object))
                         {
-                            var setDelegate = ExtractSetDelegate<T, object>(setMethod);
-                            var getDelegate = ExtractGetDelegate<T, object>(getMethod);
-                            info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetObject());
-                            info.WriteDelegate[i] = writer => writer.PutObject(getDelegate((T)info.Reference));
+                            if (array)
+                            {
+                                var setDelegate = ExtractSetDelegate<T, object[]>(setMethod);
+                                var getDelegate = ExtractGetDelegate<T, object[]>(getMethod);
+                                info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetObjectArray());
+                                info.WriteDelegate[i] = writer => writer.PutObjectArray(getDelegate((T)info.Reference));
+                            }
+                            else
+                            {
+                                var setDelegate = ExtractSetDelegate<T, object>(setMethod);
+                                var getDelegate = ExtractGetDelegate<T, object>(getMethod);
+                                info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetObject());
+                                info.WriteDelegate[i] = writer => writer.PutObject(getDelegate((T)info.Reference));
+                            }
                         }
                         else
                         {

--- a/LiteNetLib/Utils/NetSerializer.cs
+++ b/LiteNetLib/Utils/NetSerializer.cs
@@ -79,7 +79,7 @@ namespace LiteNetLib.Utils
 
         public NetSerializer() : this(0)
         {
-            
+
         }
 
         public NetSerializer(int maxStringLength)
@@ -344,9 +344,9 @@ namespace LiteNetLib.Utils
                     if (_maxStringLength <= 0)
                     {
                         info.ReadDelegate[i] =
-                            reader => setDelegate((T) info.Reference, reader.GetStringArray());
+                            reader => setDelegate((T)info.Reference, reader.GetStringArray());
                         info.WriteDelegate[i] =
-                            writer => writer.PutArray(getDelegate((T) info.Reference));
+                            writer => writer.PutArray(getDelegate((T)info.Reference));
                     }
                     else
                     {
@@ -471,7 +471,17 @@ namespace LiteNetLib.Utils
                     }
                     else
                     {
-                        throw new InvalidTypeException("Unknown property type: " + propertyType.FullName);
+                        if (propertyType == typeof(object))
+                        {
+                            var setDelegate = ExtractSetDelegate<T, object>(setMethod);
+                            var getDelegate = ExtractGetDelegate<T, object>(getMethod);
+                            info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetObject());
+                            info.WriteDelegate[i] = writer => writer.PutObject(getDelegate((T)info.Reference));
+                        }
+                        else
+                        {
+                            throw new InvalidTypeException("Unknown property type: " + propertyType.FullName);
+                        }
                     }
                 }
             }

--- a/LiteNetLib/Utils/NetSerializer.cs
+++ b/LiteNetLib/Utils/NetSerializer.cs
@@ -477,15 +477,15 @@ namespace LiteNetLib.Utils
                             {
                                 var setDelegate = ExtractSetDelegate<T, object[]>(setMethod);
                                 var getDelegate = ExtractGetDelegate<T, object[]>(getMethod);
-                                info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetObjectArray());
-                                info.WriteDelegate[i] = writer => writer.PutObjectArray(getDelegate((T)info.Reference));
+                                info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetSimpleObjectArray());
+                                info.WriteDelegate[i] = writer => writer.PutSimpleObjectArray(getDelegate((T)info.Reference));
                             }
                             else
                             {
                                 var setDelegate = ExtractSetDelegate<T, object>(setMethod);
                                 var getDelegate = ExtractGetDelegate<T, object>(getMethod);
-                                info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetObject());
-                                info.WriteDelegate[i] = writer => writer.PutObject(getDelegate((T)info.Reference));
+                                info.ReadDelegate[i] = reader => setDelegate((T)info.Reference, reader.GetSimpleObject());
+                                info.WriteDelegate[i] = writer => writer.PutSimpleObject(getDelegate((T)info.Reference));
                             }
                         }
                         else


### PR DESCRIPTION
You can now have a packet that holds an `object` property and everytime you can have different value boxed in it.

I added two test cases for `object` and `object[]` property serialization.