### PR TITLE
Socket.Dispose hangs on Linux

### DIFF
--- a/LiteNetLib/NetConstants.cs
+++ b/LiteNetLib/NetConstants.cs
@@ -46,6 +46,7 @@ namespace LiteNetLib
         public const int SocketBufferSize = 1024 * 1024 * 4; //4mb
 #endif
         public const int SocketTTL = 255;
+        public const int ReceiveTimeout = 1000;
 
         public const int HeaderSize = 1;
         public const int SequencedHeaderSize = 3;

--- a/LiteNetLib/NetSocket.cs
+++ b/LiteNetLib/NetSocket.cs
@@ -197,9 +197,12 @@ namespace LiteNetLib
                     continue;
                 }
 
-                //All ok!
-                NetUtils.DebugWrite(ConsoleColor.Blue, "[R]Received data from {0}, result: {1}", bufferNetEndPoint.ToString(), result);
-                _onMessageReceived(receiveBuffer, result, 0, bufferNetEndPoint);
+                if (result > 0)
+                {
+                    //All ok!
+                    NetUtils.DebugWrite(ConsoleColor.Blue, "[R]Received data from {0}, result: {1}", bufferNetEndPoint.ToString(), result);
+                    _onMessageReceived(receiveBuffer, result, 0, bufferNetEndPoint);
+                }
             }
         }
 
@@ -210,6 +213,8 @@ namespace LiteNetLib
             _udpSocketv4.ReceiveBufferSize = NetConstants.SocketBufferSize;
             _udpSocketv4.SendBufferSize = NetConstants.SocketBufferSize;
             _udpSocketv4.Ttl = NetConstants.SocketTTL;
+            _udpSocketv4.ReceiveTimeout = NetConstants.ReceiveTimeout;
+
             if(reuseAddress)
                 _udpSocketv4.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 #if !NETCORE
@@ -243,6 +248,7 @@ namespace LiteNetLib
             _udpSocketv6.Blocking = false;
             _udpSocketv6.ReceiveBufferSize = NetConstants.SocketBufferSize;
             _udpSocketv6.SendBufferSize = NetConstants.SocketBufferSize;
+            _udpSocketv6.ReceiveTimeout = NetConstants.ReceiveTimeout;
             //_udpSocketv6.Ttl = NetConstants.SocketTTL;
             if (reuseAddress)
                 _udpSocketv6.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);


### PR DESCRIPTION
Closing socket on Linux doesn't abort receive operation and it bring us to hang when we are stopping application and NetManager.

There are many issues on CoreFX about that:
[https://github.com/dotnet/corefx/issues/24943](#24943)
[https://github.com/dotnet/corefx/issues/20954](#20945)
[https://github.com/dotnet/corefx/issues/24677](#24677)

To fix it we should set ReceiveTimeout to socket and check receive result to process data or exit from receive loop.