### PR TITLE
NetSocket.Close fix NRE when IPv6 bind failed

### DIFF
--- a/LiteNetLib/NetSocket.cs
+++ b/LiteNetLib/NetSocket.cs
@@ -20,7 +20,7 @@ namespace LiteNetLib
         private Socket _udpSocketv6;
         private Thread _threadv4;
         private Thread _threadv6;
-        private bool _running;
+        private volatile bool _running;
         private readonly INetSocketListener _listener;
         private static readonly IPAddress MulticastAddressV6 = IPAddress.Parse (NetConstants.MulticastGroupIPv6);
         internal static readonly bool IPv6Support;
@@ -262,18 +262,26 @@ namespace LiteNetLib
         public void Close()
         {
             _running = false;
+            // first close sockets
             if (_udpSocketv4 != null)
             {
                 _udpSocketv4.Close();
                 _udpSocketv4 = null;
-                if (_threadv4 != Thread.CurrentThread)
-                    _threadv4.Join();
-                _threadv4 = null;
             }
             if (_udpSocketv6 != null)
             {
                 _udpSocketv6.Close();
                 _udpSocketv6 = null;
+            }
+            // then join threads
+            if (_threadv4 != null)
+            {
+                if (_threadv4 != Thread.CurrentThread)
+                    _threadv4.Join();
+                _threadv4 = null;
+            }
+            if (_threadv6 != null)
+            {
                 if (_threadv6 != Thread.CurrentThread)
                     _threadv6.Join();
                 _threadv6 = null;


### PR DESCRIPTION
We have and error in Unity "System.Net.Sockets.SocketException (0x80004005): Only one usage of each socket address (protocol/network address/port) is normally permitted" for IPv6 binding. Then the `Socket.Close()` fails with NRE.

I have moved the thread joins after the socket close, it's better pattern for multiple thread stopping - first trigger stop conditions for all threads, then wait all threads.

Finally, have marked `_running` at least as volatile. I do not like `volatile` since it's for real experts, safer is to use Interlocked. I may change the code if you like.