### PR TITLE
Change GetString(key.Length) to GetString()

### DIFF
--- a/LiteNetLib/ConnectionRequest.cs
+++ b/LiteNetLib/ConnectionRequest.cs
@@ -63,8 +63,7 @@ namespace LiteNetLib
                 return null;
             try
             {
-                string dataKey = Data.GetString(key.Length);
-                if (dataKey == key)
+                if (Data.GetString() == key)
                 {
                     Result = ConnectionRequestResult.Accept;
                     _listener.OnConnectionSolved(this, null, 0, 0);


### PR DESCRIPTION
To avoid any issues when server key is for example "somekey" and client sends "somekey123"