### PR TITLE
Allow NetSerializer to serialize classes with no props

### DIFF
--- a/LiteNetLib/Utils/NetSerializer.cs
+++ b/LiteNetLib/Utils/NetSerializer.cs
@@ -195,7 +195,7 @@ namespace LiteNetLib.Utils
                 BindingFlags.SetProperty);
 #endif
             int propsCount = props.Length;
-            if (props == null || propsCount == 0)
+            if (props == null)
             {
                 throw new InvalidTypeException("Type does not contain acceptable fields");
             }


### PR DESCRIPTION
I think it's desirable to have "empty" packets for situations where you want to use packets as commands with no arguments. So I removed the `propsCount` check in NetSerializer.cs

I don't know if this change will have implications elsewhere, but I tested it with no error or side-effect in my code base.