### PR TITLE
Add GetRemainingBytesSegment

### DIFF
--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -359,6 +359,12 @@ namespace LiteNetLib.Utils
             return result;
         }
 
+        public ArraySegment<byte> GetRemainingBytesSegment()
+        {
+            _position = _data.Length;
+            return new ArraySegment<byte>(_data, _position, AvailableBytes);
+        }
+
         public byte[] GetRemainingBytes()
         {
             byte[] outgoingData = new byte[AvailableBytes];


### PR DESCRIPTION
This can be useful for people with custom serialization, then they don't need to have a custom buffer/allocate per message to store the bytes.