### PR TITLE
Get rid of high CPU usage on Receive thread

### DIFF
--- a/LiteNetLib/NetSocket.cs
+++ b/LiteNetLib/NetSocket.cs
@@ -19,6 +19,7 @@ namespace LiteNetLib
 
     internal sealed class NetSocket
     {
+        public const int ReceivePollingTime = 1000000; //1 second
         private Socket _udpSocketv4;
         private Socket _udpSocketv6;
         private Thread _threadv4;
@@ -72,7 +73,7 @@ namespace LiteNetLib
                 //Reading data
                 try
                 {
-                    if (socket.Available == 0 && !socket.Poll(5000, SelectMode.SelectRead))
+                    if (socket.Available == 0 && !socket.Poll(ReceivePollingTime, SelectMode.SelectRead))
                         continue;
                     result = socket.ReceiveFrom(receiveBuffer, 0, receiveBuffer.Length, SocketFlags.None,
                         ref bufferEndPoint);


### PR DESCRIPTION
increase polling time to 1 second instead of 5 ms to prevent spinning cpu (High CPU - on iPhone X, after change, CPU usage dropped from 200% to 30%)
The receive polling is in separate thread, so blocking longer won't affect processing, since `Socket.Poll` will return early if there's data.