### PR TITLE
Don't disable IPv6 on IL2CPP with unity 2019.1

### DIFF
--- a/LiteNetLib/NetSocket.cs
+++ b/LiteNetLib/NetSocket.cs
@@ -41,7 +41,7 @@ namespace LiteNetLib
         {
 #if DISABLE_IPV6 || (!UNITY_EDITOR && ENABLE_IL2CPP && !UNITY_2018_3_OR_NEWER)
             IPv6Support = false;
-#elif !UNITY_2019_1_OR_NEWER && (!UNITY_EDITOR && ENABLE_IL2CPP && UNITY_2018_3_OR_NEWER)
+#elif !UNITY_2019_1_OR_NEWER && !UNITY_2018_4_OR_NEWER && (!UNITY_EDITOR && ENABLE_IL2CPP && UNITY_2018_3_OR_NEWER)
             string version = UnityEngine.Application.unityVersion;
             IPv6Support = Socket.OSSupportsIPv6 && int.Parse(version.Remove(version.IndexOf('f')).Split('.')[2]) >= 6;
 #elif UNITY_2018_2_OR_NEWER

--- a/LiteNetLib/NetSocket.cs
+++ b/LiteNetLib/NetSocket.cs
@@ -41,7 +41,7 @@ namespace LiteNetLib
         {
 #if DISABLE_IPV6 || (!UNITY_EDITOR && ENABLE_IL2CPP && !UNITY_2018_3_OR_NEWER)
             IPv6Support = false;
-#elif !UNITY_EDITOR && ENABLE_IL2CPP && UNITY_2018_3_OR_NEWER
+#elif !UNITY_2019_1_OR_NEWER && (!UNITY_EDITOR && ENABLE_IL2CPP && UNITY_2018_3_OR_NEWER)
             string version = UnityEngine.Application.unityVersion;
             IPv6Support = Socket.OSSupportsIPv6 && int.Parse(version.Remove(version.IndexOf('f')).Split('.')[2]) >= 6;
 #elif UNITY_2018_2_OR_NEWER


### PR DESCRIPTION
Previous logic checked for specific build of 2018.3, that's not needed with 2019.1