### PR TITLE
Added disconnect handling and DisconnectReason for NetworkUnreachable

### DIFF
--- a/LiteNetLib/INetEventListener.cs
+++ b/LiteNetLib/INetEventListener.cs
@@ -20,7 +20,7 @@ namespace LiteNetLib
         ConnectionFailed,
         Timeout,
         HostUnreachable,
-		NetworkUnreachable,
+        NetworkUnreachable,
         RemoteConnectionClose,
         DisconnectPeerCalled,
         ConnectionRejected,

--- a/LiteNetLib/INetEventListener.cs
+++ b/LiteNetLib/INetEventListener.cs
@@ -20,6 +20,7 @@ namespace LiteNetLib
         ConnectionFailed,
         Timeout,
         HostUnreachable,
+		NetworkUnreachable,
         RemoteConnectionClose,
         DisconnectPeerCalled,
         ConnectionRejected,

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -384,6 +384,11 @@ namespace LiteNetLib
                         DisconnectPeerForce(fromPeer, DisconnectReason.HostUnreachable, errorCode, null);
                     CreateEvent(NetEvent.EType.Error, remoteEndPoint: remoteEndPoint, errorCode: errorCode);
                     return -1;
+                case SocketError.NetworkUnreachable:
+	                if (TryGetPeer(remoteEndPoint, out fromPeer))
+		                DisconnectPeerForce(fromPeer, DisconnectReason.NetworkUnreachable, errorCode, null);
+	                CreateEvent(NetEvent.EType.Error, remoteEndPoint: remoteEndPoint, errorCode: errorCode);
+	                return -1;
                 case SocketError.ConnectionReset: //connection reset (connection closed)
                     if (TryGetPeer(remoteEndPoint, out fromPeer))
                         DisconnectPeerForce(fromPeer, DisconnectReason.RemoteConnectionClose, errorCode, null);


### PR DESCRIPTION
SocketError.NetworkUnreachable was not being handled, which when triggered would leave the connection in a confused state. Added NetworkUnreachable into the DisconnectReason enum in INetEventListener.cs and case into NetManager.cs