### PR TITLE
Small Fixes

### DIFF
--- a/LibSample/BroadcastTest.cs
+++ b/LibSample/BroadcastTest.cs
@@ -112,8 +112,7 @@ namespace LibSample
             //Server
             _serverListener = new ServerListener();
 
-            NetManager server = new NetManager(_serverListener);
-            server.BroadcastReceiveEnabled = true;
+            NetManager server = new NetManager(_serverListener) {BroadcastReceiveEnabled = true};
             if (!server.Start(9050))
             {
                 Console.WriteLine("Server start failed");

--- a/LibSample/HolePunchServerTest.cs
+++ b/LibSample/HolePunchServerTest.cs
@@ -8,8 +8,8 @@ namespace LibSample
 {
     class WaitPeer
     {
-        public IPEndPoint InternalAddr { get; private set; }
-        public IPEndPoint ExternalAddr { get; private set; }
+        public IPEndPoint InternalAddr { get; }
+        public IPEndPoint ExternalAddr { get; }
         public DateTime RefreshTime { get; private set; }
 
         public void Refresh()
@@ -39,8 +39,7 @@ namespace LibSample
 
         void INatPunchListener.OnNatIntroductionRequest(IPEndPoint localEndPoint, IPEndPoint remoteEndPoint, string token)
         {
-            WaitPeer wpeer;
-            if (_waitingPeers.TryGetValue(token, out wpeer))
+            if (_waitingPeers.TryGetValue(token, out WaitPeer wpeer))
             {
                 if (wpeer.InternalAddr.Equals(localEndPoint) &&
                     wpeer.ExternalAddr.Equals(remoteEndPoint))
@@ -121,13 +120,11 @@ namespace LibSample
                 Console.WriteLine("Success C2. Connecting to C1: {0}, connection created: {1}", point, peer != null);
             };
 
-            _c1 = new NetManager(netListener);
-            _c1.NatPunchEnabled = true;
+            _c1 = new NetManager(netListener) {NatPunchEnabled = true};
             _c1.NatPunchModule.Init(natPunchListener1);
             _c1.Start();
 
-            _c2 = new NetManager(netListener);
-            _c2.NatPunchEnabled = true;
+            _c2 = new NetManager(netListener) {NatPunchEnabled = true};
             _c2.NatPunchModule.Init(natPunchListener2);
             _c2.Start();
 

--- a/LibSample/Program.cs
+++ b/LibSample/Program.cs
@@ -5,7 +5,7 @@ namespace LibSample
 {
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             //Test ntp
             NtpRequest ntpRequest = null;

--- a/LibSample/SerializerBenchmark.cs
+++ b/LibSample/SerializerBenchmark.cs
@@ -85,9 +85,7 @@ namespace LibSample
 
             public static SomeVector2 Deserialize(NetDataReader reader)
             {
-                SomeVector2 res = new SomeVector2();
-                res.X = reader.GetInt();
-                res.Y = reader.GetInt();
+                SomeVector2 res = new SomeVector2 {X = reader.GetInt(), Y = reader.GetInt()};
                 return res;
             }
         }
@@ -155,7 +153,7 @@ namespace LibSample
             //Prewarm cpu
             for (int i = 0; i < 10000000; i++)
             {
-                double c = Math.Sin(i);
+                _ = Math.Sin(i);
             }
 
             //Test binary formatter

--- a/LibSample/SpeedBench.cs
+++ b/LibSample/SpeedBench.cs
@@ -19,11 +19,10 @@ namespace LibSample
 
             public Server()
             {
-                _server = new NetManager(this);
-                _server.AutoRecycle = true;
-                _server.UpdateTime = 1;
-                _server.SimulatePacketLoss = false;
-                _server.SimulationPacketLossChance = 20;
+                _server = new NetManager(this)
+                {
+                    AutoRecycle = true, UpdateTime = 1, SimulatePacketLoss = false, SimulationPacketLossChance = 20
+                };
                 _server.Start(9050);
             }
 
@@ -93,11 +92,10 @@ namespace LibSample
             {
                 _writer = new NetDataWriter();
 
-                _client = new NetManager(this);
-                _client.UnsyncedEvents = true;
-                _client.AutoRecycle = true;
-                _client.SimulatePacketLoss = false;
-                _client.SimulationPacketLossChance = 20;
+                _client = new NetManager(this)
+                {
+                    UnsyncedEvents = true, AutoRecycle = true, SimulatePacketLoss = false, SimulationPacketLossChance = 20
+                };
                 _client.Start();
             }
 
@@ -158,9 +156,9 @@ namespace LibSample
             }
         }
         private const string DATA = "The quick brown fox jumps over the lazy dog";
-        private static int MAX_LOOP_COUNT = 750;
-        private static int UNRELIABLE_MESSAGES_PER_LOOP = 1000;
-        private static int RELIABLE_MESSAGES_PER_LOOP = 350;
+        private const int MAX_LOOP_COUNT = 750;
+        private const int UNRELIABLE_MESSAGES_PER_LOOP = 1000;
+        private const int RELIABLE_MESSAGES_PER_LOOP = 350;
         private static bool CLIENT_RUNNING = true;
 
         public void Run()

--- a/LiteNetLib.Tests/CommunicationTest.cs
+++ b/LiteNetLib.Tests/CommunicationTest.cs
@@ -422,7 +422,7 @@ namespace LiteNetLib.Tests
             client.Stop();
 
             var connected = false;
-            listener.PeerConnectedEvent += (peer) =>
+            listener.PeerConnectedEvent += peer =>
             {
                 connected = true;
             };

--- a/LiteNetLib.Tests/NetSerializerTest.cs
+++ b/LiteNetLib.Tests/NetSerializerTest.cs
@@ -53,9 +53,7 @@ namespace LiteNetLib.Tests
 
             public static SomeVector2 Deserialize(NetDataReader reader)
             {
-                var res = new SomeVector2();
-                res.X = reader.GetInt();
-                res.Y = reader.GetInt();
+                var res = new SomeVector2 {X = reader.GetInt(), Y = reader.GetInt()};
                 return res;
             }
         }

--- a/LiteNetLib.Tests/TestUtility/NetManagerStack.cs
+++ b/LiteNetLib.Tests/TestUtility/NetManagerStack.cs
@@ -87,14 +87,13 @@ namespace LiteNetLib.Tests.TestUtility
 
         private NetContainer GetNetworkManager(ushort id, bool isClient)
         {
-            NetContainer container;
             if (id == 0)
             {
                 Assert.Fail("Id cannot be 0");
             }
 
             var key = isClient ? id : (uint) id << 16;
-            if (!_managers.TryGetValue(key, out container))
+            if (!_managers.TryGetValue(key, out NetContainer container))
             {
                 var listener = new EventBasedNetListener();
                 listener.ConnectionRequestEvent += request =>

--- a/LiteNetLib/BaseChannel.cs
+++ b/LiteNetLib/BaseChannel.cs
@@ -16,7 +16,13 @@ namespace LiteNetLib
 
         public int PacketsInQueue
         {
-            get { return OutgoingQueue.Count; }
+            get
+            {
+                lock (OutgoingQueue)
+                {
+                    return OutgoingQueue.Count;
+                }
+            }
         }
 
         public void AddToQueue(NetPacket packet)

--- a/LiteNetLib/ConnectionRequest.cs
+++ b/LiteNetLib/ConnectionRequest.cs
@@ -94,17 +94,12 @@ namespace LiteNetLib
             return _listener.OnConnectionSolved(this, null, 0, 0);
         }
         
-        public void Reject(byte[] rejectData, int start, int length, bool force)
+        public void Reject(byte[] rejectData, int start, int length, bool force = false)
         {
             if (!TryActivate())
                 return;
             Result = force ? ConnectionRequestResult.RejectForce : ConnectionRequestResult.Reject;
             _listener.OnConnectionSolved(this, rejectData, start, length);
-        }
-
-        public void Reject(byte[] rejectData, int start, int length)
-        {
-            Reject(rejectData, start, length, false);
         }
 
 

--- a/LiteNetLib/INetEventListener.cs
+++ b/LiteNetLib/INetEventListener.cs
@@ -84,7 +84,7 @@ namespace LiteNetLib
         /// </summary>
         /// <param name="remoteEndPoint">From address (IP and Port)</param>
         /// <param name="reader">Message data</param>
-        /// <param name="messageType">Message type (simple, discovery request or responce)</param>
+        /// <param name="messageType">Message type (simple, discovery request or response)</param>
         void OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType);
 
         /// <summary>

--- a/LiteNetLib/NetPacket.cs
+++ b/LiteNetLib/NetPacket.cs
@@ -130,7 +130,7 @@ namespace LiteNetLib
             return GetHeaderSize(Property);
         }
 
-        //Packet contstructor from byte array
+        //Packet constructor from byte array
         public bool FromBytes(byte[] data, int start, int packetSize)
         {
             //Reading property

--- a/LiteNetLib/NetPacketPool.cs
+++ b/LiteNetLib/NetPacketPool.cs
@@ -63,7 +63,7 @@ namespace LiteNetLib
         {
             if (packet.RawData.Length > NetConstants.MaxPacketSize)
             {
-                //Dont pool big packets. Save memory
+                //Don't pool big packets. Save memory
                 return;
             }
 

--- a/LiteNetLib/NetSocket.cs
+++ b/LiteNetLib/NetSocket.cs
@@ -119,9 +119,7 @@ namespace LiteNetLib
                 return false;
             LocalPort = ((IPEndPoint) _udpSocketv4.LocalEndPoint).Port;
             _running = true;
-            _threadv4 = new Thread(ReceiveLogic);
-            _threadv4.Name = "SocketThreadv4(" + LocalPort + ")";
-            _threadv4.IsBackground = true;
+            _threadv4 = new Thread(ReceiveLogic) {Name = "SocketThreadv4(" + LocalPort + ")", IsBackground = true};
             _threadv4.Start(_udpSocketv4);
 
             //Check IPv6 support
@@ -146,9 +144,7 @@ namespace LiteNetLib
                     // Unity3d throws exception - ignored
                 }
 
-                _threadv6 = new Thread(ReceiveLogic);
-                _threadv6.Name = "SocketThreadv6(" + LocalPort + ")";
-                _threadv6.IsBackground = true;
+                _threadv6 = new Thread(ReceiveLogic) {Name = "SocketThreadv6(" + LocalPort + ")", IsBackground = true};
                 _threadv6.Start(_udpSocketv6);
             }
 
@@ -195,7 +191,7 @@ namespace LiteNetLib
                 try { socket.DontFragment = true; }
                 catch (SocketException e)
                 {
-                    NetDebug.WriteError("[B]DontFragment error: {0}", e.SocketErrorCode);
+                    NetDebug.WriteError("[B]Don'tFragment error: {0}", e.SocketErrorCode);
                 }
 
                 try { socket.EnableBroadcast = true; }
@@ -209,7 +205,7 @@ namespace LiteNetLib
             try
             {
                 socket.Bind(ep);
-                NetDebug.Write(NetLogLevel.Trace, "[B]Successfully binded to port: {0}", ((IPEndPoint)socket.LocalEndPoint).Port);
+                NetDebug.Write(NetLogLevel.Trace, "[B]Successfully bound to port: {0}", ((IPEndPoint)socket.LocalEndPoint).Port);
             }
             catch (SocketException bindException)
             {

--- a/LiteNetLib/ReliableChannel.cs
+++ b/LiteNetLib/ReliableChannel.cs
@@ -227,10 +227,10 @@ namespace LiteNetLib
 
             //If very new - move window
             int ackIdx;
-            int ackByte;
-            int ackBit;
             lock (_outgoingAcks)
             {
+                int ackByte;
+                int ackBit;
                 if (relate >= _windowSize)
                 {
                     //New window position
@@ -267,7 +267,7 @@ namespace LiteNetLib
             //detailed check
             if (seq == _remoteSequence)
             {
-                NetDebug.Write("[RR]ReliableInOrder packet succes");
+                NetDebug.Write("[RR]ReliableInOrder packet success");
                 Peer.AddIncomingPacket(packet);
                 _remoteSequence = (_remoteSequence + 1) % NetConstants.MaxSequence;
 
@@ -276,7 +276,7 @@ namespace LiteNetLib
                     NetPacket p;
                     while ((p = _receivedPackets[_remoteSequence % _windowSize]) != null)
                     {
-                        //process holded packet
+                        //process held packet
                         _receivedPackets[_remoteSequence % _windowSize] = null;
                         Peer.AddIncomingPacket(p);
                         _remoteSequence = (_remoteSequence + 1) % NetConstants.MaxSequence;
@@ -294,7 +294,7 @@ namespace LiteNetLib
                 return true;
             }
 
-            //holded packet
+            //Held packet
             if (_ordered)
             {
                 _receivedPackets[ackIdx] = packet;

--- a/LiteNetLib/Utils/CRC32C.cs
+++ b/LiteNetLib/Utils/CRC32C.cs
@@ -5,7 +5,7 @@ using System.Runtime.Intrinsics.X86;
 
 namespace LiteNetLib.Utils
 {
-    //Implemenatation from Crc32.NET
+    //Implementation from Crc32.NET
     public static class CRC32C
     {
 #if NETCOREAPP3_0

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -9,7 +9,6 @@ namespace LiteNetLib.Utils
         protected byte[] _data;
         protected int _position;
         protected int _dataSize;
-        private int _offset;
 
         public byte[] RawData
         {
@@ -21,14 +20,11 @@ namespace LiteNetLib.Utils
             get { return _dataSize; }
         }
 
-        public int UserDataOffset
-        {
-            get { return _offset; }
-        }
+        public int UserDataOffset { get; private set; }
 
         public int UserDataSize
         {
-            get { return _dataSize - _offset; }
+            get { return _dataSize - UserDataOffset; }
         }
 
         public bool IsNull
@@ -60,7 +56,7 @@ namespace LiteNetLib.Utils
         {
             _data = dataWriter.Data;
             _position = 0;
-            _offset = 0;
+            UserDataOffset = 0;
             _dataSize = dataWriter.Length;
         }
 
@@ -68,7 +64,7 @@ namespace LiteNetLib.Utils
         {
             _data = source;
             _position = 0;
-            _offset = 0;
+            UserDataOffset = 0;
             _dataSize = source.Length;
         }
 
@@ -76,7 +72,7 @@ namespace LiteNetLib.Utils
         {
             _data = source;
             _position = offset;
-            _offset = offset;
+            UserDataOffset = offset;
             _dataSize = source.Length;
         }
 
@@ -84,7 +80,7 @@ namespace LiteNetLib.Utils
         {
             _data = source;
             _position = offset;
-            _offset = offset;
+            UserDataOffset = offset;
             _dataSize = maxSize;
         }
 

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -20,11 +20,7 @@ namespace LiteNetLib.Utils
         {
         }
 
-        public NetDataWriter(bool autoResize) : this(autoResize, InitialSize)
-        {
-        }
-
-        public NetDataWriter(bool autoResize, int initialSize)
+        public NetDataWriter(bool autoResize, int initialSize = InitialSize)
         {
             _data = new byte[initialSize];
             _autoResize = autoResize;

--- a/LiteNetLib/Utils/NetPacketProcessor.cs
+++ b/LiteNetLib/Utils/NetPacketProcessor.cs
@@ -36,7 +36,7 @@ namespace LiteNetLib.Utils
             string typeName = typeof(T).FullName;
             for (var i = 0; i < typeName.Length; i++)
             {
-                hash = hash ^ typeName[i];
+                hash ^= typeName[i];
                 hash *= 1099511628211UL; //prime
             }
             HashCache<T>.Initialized = true;
@@ -110,16 +110,6 @@ namespace LiteNetLib.Utils
                 ReadPacket(reader, userData);
         }
 
-        /// <summary>
-        /// Reads one packet from NetDataReader and calls OnReceive delegate
-        /// </summary>
-        /// <param name="reader">NetDataReader with packet</param>
-        /// <exception cref="ParseException">Malformed packet</exception>
-        public void ReadPacket(NetDataReader reader)
-        {
-            ReadPacket(reader, null);
-        }
-
         public void Send<T>(NetPeer peer, T packet, DeliveryMethod options) where T : class, new()
         {
             _netDataWriter.Reset();
@@ -182,7 +172,7 @@ namespace LiteNetLib.Utils
         /// <param name="reader">NetDataReader with packet</param>
         /// <param name="userData">Argument that passed to OnReceivedEvent</param>
         /// <exception cref="ParseException">Malformed packet</exception>
-        public void ReadPacket(NetDataReader reader, object userData)
+        public void ReadPacket(NetDataReader reader, object userData = null)
         {
             GetCallbackFromData(reader)(reader, userData);
         }
@@ -191,7 +181,7 @@ namespace LiteNetLib.Utils
         /// Register and subscribe to packet receive event
         /// </summary>
         /// <param name="onReceive">event that will be called when packet deserialized with ReadPacket method</param>
-        /// <param name="packetConstructor">Method that constructs packet intead of slow Activator.CreateInstance</param>
+        /// <param name="packetConstructor">Method that constructs packet instead of slow Activator.CreateInstance</param>
         /// <exception cref="InvalidTypeException"><typeparamref name="T"/>'s fields are not supported, or it has no fields</exception>
         public void Subscribe<T>(Action<T> onReceive, Func<T> packetConstructor) where T : class, new()
         {
@@ -208,7 +198,7 @@ namespace LiteNetLib.Utils
         /// Register and subscribe to packet receive event (with userData)
         /// </summary>
         /// <param name="onReceive">event that will be called when packet deserialized with ReadPacket method</param>
-        /// <param name="packetConstructor">Method that constructs packet intead of slow Activator.CreateInstance</param>
+        /// <param name="packetConstructor">Method that constructs packet instead of slow Activator.CreateInstance</param>
         /// <exception cref="InvalidTypeException"><typeparamref name="T"/>'s fields are not supported, or it has no fields</exception>
         public void Subscribe<T, TUserData>(Action<T, TUserData> onReceive, Func<T> packetConstructor) where T : class, new()
         {
@@ -223,7 +213,7 @@ namespace LiteNetLib.Utils
 
         /// <summary>
         /// Register and subscribe to packet receive event
-        /// This metod will overwrite last received packet class on receive (less garbage)
+        /// This method will overwrite last received packet class on receive (less garbage)
         /// </summary>
         /// <param name="onReceive">event that will be called when packet deserialized with ReadPacket method</param>
         /// <exception cref="InvalidTypeException"><typeparamref name="T"/>'s fields are not supported, or it has no fields</exception>
@@ -240,7 +230,7 @@ namespace LiteNetLib.Utils
 
         /// <summary>
         /// Register and subscribe to packet receive event
-        /// This metod will overwrite last received packet class on receive (less garbage)
+        /// This method will overwrite last received packet class on receive (less garbage)
         /// </summary>
         /// <param name="onReceive">event that will be called when packet deserialized with ReadPacket method</param>
         /// <exception cref="InvalidTypeException"><typeparamref name="T"/>'s fields are not supported, or it has no fields</exception>

--- a/LiteNetLib/Utils/NetSerializer.cs
+++ b/LiteNetLib/Utils/NetSerializer.cs
@@ -464,57 +464,57 @@ namespace LiteNetLib.Utils
                 if (getMethod == null || setMethod == null)
                     continue;
 
-                FastCall<T> serialzer = null;
+                FastCall<T> serializer = null;
                 if (propertyType.IsEnum)
                 {
                     var underlyingType = Enum.GetUnderlyingType(propertyType);
                     if (underlyingType == typeof(byte))
-                        serialzer = new EnumByteSerializer<T>(property, propertyType);
+                        serializer = new EnumByteSerializer<T>(property, propertyType);
                     else if (underlyingType == typeof(int))
-                        serialzer = new EnumIntSerializer<T>(property, propertyType);
+                        serializer = new EnumIntSerializer<T>(property, propertyType);
                     else
                         throw new InvalidTypeException("Not supported enum underlying type: " + underlyingType.Name);
                 }
                 else if (elementType == typeof(string))
-                    serialzer = new StringSerializer<T>(_maxStringLength);
+                    serializer = new StringSerializer<T>(_maxStringLength);
                 else if (elementType == typeof(bool))
-                    serialzer = new BoolSerializer<T>();
+                    serializer = new BoolSerializer<T>();
                 else if (elementType == typeof(byte))
-                    serialzer = new ByteSerializer<T>();
+                    serializer = new ByteSerializer<T>();
                 else if (elementType == typeof(sbyte))
-                    serialzer = new SByteSerializer<T>();
+                    serializer = new SByteSerializer<T>();
                 else if (elementType == typeof(short))
-                    serialzer = new ShortSerializer<T>();
+                    serializer = new ShortSerializer<T>();
                 else if (elementType == typeof(ushort))
-                    serialzer = new UShortSerializer<T>();
+                    serializer = new UShortSerializer<T>();
                 else if (elementType == typeof(int))
-                    serialzer = new IntSerializer<T>();
+                    serializer = new IntSerializer<T>();
                 else if (elementType == typeof(uint))
-                    serialzer = new UIntSerializer<T>();
+                    serializer = new UIntSerializer<T>();
                 else if (elementType == typeof(long))
-                    serialzer = new LongSerializer<T>();
+                    serializer = new LongSerializer<T>();
                 else if (elementType == typeof(ulong))
-                    serialzer = new ULongSerializer<T>();
+                    serializer = new ULongSerializer<T>();
                 else if (elementType == typeof(float))
-                    serialzer = new FloatSerializer<T>();
+                    serializer = new FloatSerializer<T>();
                 else if (elementType == typeof(double))
-                    serialzer = new DoubleSerializer<T>();
+                    serializer = new DoubleSerializer<T>();
                 else if (elementType == typeof(char))
-                    serialzer = new CharSerializer<T>();
+                    serializer = new CharSerializer<T>();
                 else if (elementType == typeof(IPEndPoint))
-                    serialzer = new IPEndPointSerializer<T>();
+                    serializer = new IPEndPointSerializer<T>();
                 else
                 {
                     CustomType customType;
                     _registeredTypes.TryGetValue(elementType, out customType);
                     if (customType != null)
-                        serialzer = customType.Get<T>();
+                        serializer = customType.Get<T>();
                 }
 
-                if (serialzer != null)
+                if (serializer != null)
                 {
-                    serialzer.Init(getMethod, setMethod, propertyType.IsArray);
-                    serializers.Add(serialzer);
+                    serializer.Init(getMethod, setMethod, propertyType.IsArray);
+                    serializers.Add(serializer);
                 }
                 else
                 {

--- a/LiteNetLib/Utils/NtpPacket.cs
+++ b/LiteNetLib/Utils/NtpPacket.cs
@@ -92,7 +92,7 @@ namespace LiteNetLib.Utils
         /// <para>
         /// Distance from the reference clock. This property is set only in server reply packets.
         /// Servers connected directly to reference clock hardware set this property to 1.
-        /// Statum number is incremented by 1 on every hop down the NTP server hierarchy.
+        /// Stratum number is incremented by 1 on every hop down the NTP server hierarchy.
         /// </para>
         /// <para>
         /// Special value 0 indicates that this packet is a Kiss-o'-Death message
@@ -293,8 +293,7 @@ namespace LiteNetLib.Utils
         /// <returns></returns>
         public static NtpPacket FromServerResponse(byte[] bytes, DateTime destinationTimestamp)
         {
-            var packet = new NtpPacket(bytes);
-            packet.DestinationTimestamp = destinationTimestamp;
+            var packet = new NtpPacket(bytes) {DestinationTimestamp = destinationTimestamp};
             return packet;
         }
 
@@ -423,6 +422,6 @@ namespace LiteNetLib.Utils
         /// <summary>
         /// Identifies server-to-client SNTP packet.
         /// </summary>
-        Server = 4,
+        Server = 4
     }
 }

--- a/LiteNetLib/Utils/NtpRequest.cs
+++ b/LiteNetLib/Utils/NtpRequest.cs
@@ -87,7 +87,7 @@ namespace LiteNetLib.Utils
 
         /// <summary>
         /// Send request to the NTP server calls callback (if success).
-        /// In case of error the callbacke is called with null param.
+        /// In case of error the callback is called with null param.
         /// </summary>
         public void Send()
         {


### PR DESCRIPTION
Fix Typos,
Object Initializer,
Declare in inner scope,
Remove unused private setter,
Remove unused args param in sample,
Remove Unused parenthesis,
Inline 'out' parameters,
Objects are locked whenever accessed,
Optional parameters instead od overloads,
Make properties to auto properties,
Compound assignment,
Remove unused commas,