### PR TITLE
Add Span overloads to public methods

### DIFF
--- a/LiteNetLib/ConnectionRequest.cs
+++ b/LiteNetLib/ConnectionRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading;
 using LiteNetLib.Utils;
 
@@ -93,7 +94,27 @@ namespace LiteNetLib
             Result = ConnectionRequestResult.Accept;
             return _listener.OnConnectionSolved(this, null, 0, 0);
         }
-        
+
+#if NETCOREAPP2_1 || NETCOREAPP3_0 || NETSTANDARD2_1
+        public void Reject(ReadOnlySpan<byte> rejectData, bool force)
+        {
+            if (!TryActivate())
+                return;
+            Result = force ? ConnectionRequestResult.RejectForce : ConnectionRequestResult.Reject;
+            _listener.OnConnectionSolved(this, rejectData);
+        }
+
+        public void Reject(ReadOnlySpan<byte> rejectData)
+        {
+            Reject(rejectData, false);
+        }
+
+        public void RejectForce(ReadOnlySpan<byte> rejectData)
+        {
+            Reject(rejectData, true);
+        }
+#endif
+
         public void Reject(byte[] rejectData, int start, int length, bool force)
         {
             if (!TryActivate())
@@ -106,7 +127,6 @@ namespace LiteNetLib
         {
             Reject(rejectData, start, length, false);
         }
-
 
         public void RejectForce(byte[] rejectData, int start, int length)
         {

--- a/LiteNetLib/LiteNetLib.csproj
+++ b/LiteNetLib/LiteNetLib.csproj
@@ -3,15 +3,20 @@
   <PropertyGroup>
     <AssemblyName>LiteNetLib</AssemblyName>
     <RootNamespace>LiteNetLib</RootNamespace>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;netstandard2.0;netcoreapp2.1;netcoreapp3.0;netstandard2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netstandard2.1'">
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1' and '$(TargetFramework)' != 'netcoreapp3.0' and '$(TargetFramework)' != 'netstandard2.1'">
     <LangVersion>4</LangVersion>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;netstandard2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <LangVersion>4</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/LiteNetLib/NetPacket.cs
+++ b/LiteNetLib/NetPacket.cs
@@ -149,6 +149,28 @@ namespace LiteNetLib
             Size = (ushort)packetSize;
             return true;
         }
+
+#if NETCOREAPP2_1 || NETCOREAPP3_0 || NETSTANDARD2_1
+        //Packet contstructor from byte array
+        public bool FromBytes(ReadOnlySpan<byte> data)
+        {
+            int packetSize = data.Length;
+            //Reading property
+            byte property = (byte)(data[0] & 0x1F);
+            bool fragmented = (data[0] & 0x80) != 0;
+            int headerSize = GetHeaderSize((PacketProperty)property);
+
+            if (property > LastProperty || packetSize < headerSize ||
+                (fragmented && packetSize < headerSize + NetConstants.FragmentHeaderSize))
+            {
+                return false;
+            }
+
+            data.CopyTo(new Span<byte>(RawData, 0, packetSize));
+            Size = (ushort)packetSize;
+            return true;
+        }
+#endif
     }
 
     internal sealed class NetConnectRequestPacket

--- a/LiteNetLib/NetPacketPool.cs
+++ b/LiteNetLib/NetPacketPool.cs
@@ -18,6 +18,18 @@ namespace LiteNetLib
             return packet;
         }
 
+#if NETCOREAPP2_1 || NETCOREAPP3_0 || NETSTANDARD2_1
+        public NetPacket GetWithData(PacketProperty property, ReadOnlySpan<byte> data)
+        {
+            int length = data.Length;
+            int headerSize = NetPacket.GetHeaderSize(property);
+            NetPacket packet = GetPacket(length + headerSize);
+            packet.Property = property;
+            data.CopyTo(new Span<byte>(packet.RawData, headerSize, length));
+            return packet;
+        }
+#endif
+
         //Get packet with size
         public NetPacket GetWithProperty(PacketProperty property, int size)
         {

--- a/LiteNetLib/Utils/FastBitConverter.cs
+++ b/LiteNetLib/Utils/FastBitConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace LiteNetLib.Utils
@@ -114,5 +115,98 @@ namespace LiteNetLib.Utils
         {
             WriteLittleEndian(bytes, startIndex, value);
         }
+
+#if NETCOREAPP2_1 || NETCOREAPP3_0 || NETSTANDARD2_1
+        private static void WriteLittleEndian(Span<byte> bytes, ulong data)
+        {
+#if BIGENDIAN
+            bytes[7] = (byte)(data);
+            bytes[6] = (byte)(data >> 8);
+            bytes[5] = (byte)(data >> 16);
+            bytes[4] = (byte)(data >> 24);
+            bytes[3] = (byte)(data >> 32);
+            bytes[2] = (byte)(data >> 40);
+            bytes[1] = (byte)(data >> 48);
+            bytes[0] = (byte)(data >> 56);
+#else
+            bytes[0] = (byte)(data);
+            bytes[1] = (byte)(data >> 8);
+            bytes[2] = (byte)(data >> 16);
+            bytes[3] = (byte)(data >> 24);
+            bytes[4] = (byte)(data >> 32);
+            bytes[5] = (byte)(data >> 40);
+            bytes[6] = (byte)(data >> 48);
+            bytes[7] = (byte)(data >> 56);
+#endif
+        }
+
+        private static void WriteLittleEndian(Span<byte> bytes, int data)
+        {
+#if BIGENDIAN
+            bytes[3] = (byte)(data);
+            bytes[2] = (byte)(data >> 8);
+            bytes[1] = (byte)(data >> 16);
+            bytes[0] = (byte)(data >> 24);
+#else
+            bytes[0] = (byte)(data);
+            bytes[1] = (byte)(data >> 8);
+            bytes[2] = (byte)(data >> 16);
+            bytes[3] = (byte)(data >> 24);
+#endif
+        }
+
+        public static void WriteLittleEndian(Span<byte> bytes, short data)
+        {
+#if BIGENDIAN
+            bytes[1] = (byte)(data);
+            bytes[0] = (byte)(data >> 8);
+#else
+            bytes[0] = (byte)(data);
+            bytes[1] = (byte)(data >> 8);
+#endif
+        }
+
+        public static void GetBytes(Span<byte> bytes, double value)
+        {
+            ConverterHelperDouble ch = new ConverterHelperDouble { Adouble = value };
+            WriteLittleEndian(bytes, ch.Along);
+        }
+
+        public static void GetBytes(Span<byte> bytes, float value)
+        {
+            ConverterHelperFloat ch = new ConverterHelperFloat { Afloat = value };
+            WriteLittleEndian(bytes, ch.Aint);
+        }
+
+        public static void GetBytes(Span<byte> bytes, short value)
+        {
+            WriteLittleEndian(bytes, value);
+        }
+
+        public static void GetBytes(Span<byte> bytes, ushort value)
+        {
+            WriteLittleEndian(bytes, (short)value);
+        }
+
+        public static void GetBytes(Span<byte> bytes, int value)
+        {
+            WriteLittleEndian(bytes, value);
+        }
+
+        public static void GetBytes(Span<byte> bytes, uint value)
+        {
+            WriteLittleEndian(bytes, (int)value);
+        }
+
+        public static void GetBytes(Span<byte> bytes, long value)
+        {
+            WriteLittleEndian(bytes, (ulong)value);
+        }
+
+        public static void GetBytes(Span<byte> bytes, ulong value)
+        {
+            WriteLittleEndian(bytes, value);
+        }
+#endif
     }
 }

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -208,7 +208,17 @@ namespace LiteNetLib.Utils
             Buffer.BlockCopy(data, 0, _data, _position, data.Length);
             _position += data.Length;
         }
-        
+
+#if NETCOREAPP2_1 || NETCOREAPP3_0 || NETSTANDARD2_1
+        public void Put(ReadOnlySpan<byte> data)
+        {
+            if (_autoResize)
+                ResizeIfNeed(_position + data.Length);
+            data.CopyTo(new Span<byte>(_data, _position, data.Length));
+            _position += data.Length;
+        }
+#endif
+
         public void PutSBytesWithLength(sbyte[] data, int offset, int length)
         {
             if (_autoResize)


### PR DESCRIPTION
Allows sending data from Spans without coping their contents to temporary arrays.
Works only with .Net Standard 2.1, .Net Core 2.1 and newer.