### PR TITLE
Fix Server Usage Sample to use ConnectedPeerCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ server.Start(9050 /* port */);
 
 listener.ConnectionRequestEvent += request =>
 {
-    if(server.PeersCount < 10 /* max connections */)
+    if(server.ConnectedPeersCount < 10 /* max connections */)
         request.AcceptIfKey("SomeConnectionKey");
     else
         request.Reject();


### PR DESCRIPTION
In Server Usage Sample replace call to non-existent NetManager.PeerCount with NetManager.ConnectedPeerCount