### PR TITLE
Optimize SSE CRC

### DIFF
--- a/LiteNetLib/LiteNetLib.csproj
+++ b/LiteNetLib/LiteNetLib.csproj
@@ -3,15 +3,20 @@
   <PropertyGroup>
     <AssemblyName>LiteNetLib</AssemblyName>
     <RootNamespace>LiteNetLib</RootNamespace>
-    <LangVersion>4</LangVersion>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;netstandard2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+    <LangVersion>4</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <LangVersion>4</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
I've benchmarked the original code and my version, the latter seems about 3 times faster than former unless with empty data.

Crc32CSseLnL is the original, Crc32CSsePet is the new one.
``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 8.1 (6.3.9600.0)
Intel Core i3-4130 CPU 3.40GHz (Haswell), 1 CPU, 4 logical and 2 physical cores
Frequency=3319348 Hz, Resolution=301.2640 ns, Timer=TSC
.NET Core SDK=5.0.100-rc.1.20452.10
  [Host]        : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  .NET Core 3.1 : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.45114, CoreFX 5.0.20.45114), X64 RyuJIT
```

|           Method |           Job |       Runtime | DataSize |          Mean |       Error |      StdDev |         Median | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |-------------- |-------------- |--------- |--------------:|------------:|------------:|---------------:|------:|--------:|------:|------:|------:|----------:|
|     **Crc32CSseLnL** | **.NET Core 3.1** | **.NET Core 3.1** |        **0** |      **1.143 ns** |   **0.0117 ns** |   **0.0103 ns** |      **1.1447 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|     Crc32CSsePet | .NET Core 3.1 | .NET Core 3.1 |        0 |      1.802 ns |   0.0096 ns |   0.0085 ns |      1.8013 ns |  1.58 |    0.02 |     - |     - |     - |         - |
|                  |               |               |          |               |             |             |                |       |         |       |       |       |           |
|     Crc32CSseLnL | .NET Core 5.0 | .NET Core 5.0 |        0 |      1.001 ns |   0.0109 ns |   0.0097 ns |      0.9973 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|     Crc32CSsePet | .NET Core 5.0 | .NET Core 5.0 |        0 |      1.543 ns |   0.0473 ns |   0.0442 ns |      1.5346 ns |  1.54 |    0.05 |     - |     - |     - |         - |
|                  |               |               |          |               |             |             |                |       |         |       |       |       |           |
|     **Crc32CSseLnL** | **.NET Core 3.1** | **.NET Core 3.1** |      **100** |     **32.032 ns** |   **0.3152 ns** |   **0.2948 ns** |     **32.0481 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|     Crc32CSsePet | .NET Core 3.1 | .NET Core 3.1 |      100 |     11.250 ns |   0.1102 ns |   0.0977 ns |     11.2251 ns |  0.35 |    0.00 |     - |     - |     - |         - |
|                  |               |               |          |               |             |             |                |       |         |       |       |       |           |
|     Crc32CSseLnL | .NET Core 5.0 | .NET Core 5.0 |      100 |     32.234 ns |   0.5256 ns |   0.4917 ns |     32.0780 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|     Crc32CSsePet | .NET Core 5.0 | .NET Core 5.0 |      100 |     10.539 ns |   0.0428 ns |   0.0357 ns |     10.5383 ns |  0.33 |    0.01 |     - |     - |     - |         - |
|                  |               |               |          |               |             |             |                |       |         |       |       |       |           |
|     **Crc32CSseLnL** | **.NET Core 3.1** | **.NET Core 3.1** |     **1500** |    **465.302 ns** |   **3.4581 ns** |   **2.6999 ns** |    **464.9618 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|     Crc32CSsePet | .NET Core 3.1 | .NET Core 3.1 |     1500 |    157.375 ns |   0.2756 ns |   0.2443 ns |    157.4440 ns |  0.34 |    0.00 |     - |     - |     - |         - |
|                  |               |               |          |               |             |             |                |       |         |       |       |       |           |
|     Crc32CSseLnL | .NET Core 5.0 | .NET Core 5.0 |     1500 |    458.022 ns |   2.6390 ns |   2.4685 ns |    457.6158 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|     Crc32CSsePet | .NET Core 5.0 | .NET Core 5.0 |     1500 |    155.892 ns |   0.2856 ns |   0.2671 ns |    155.8101 ns |  0.34 |    0.00 |     - |     - |     - |         - |
|                  |               |               |          |               |             |             |                |       |         |       |       |       |           |
|     **Crc32CSseLnL** | **.NET Core 3.1** | **.NET Core 3.1** |    **65536** | **20,892.542 ns** | **155.0414 ns** | **137.4402 ns** | **20,935.7276 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|     Crc32CSsePet | .NET Core 3.1 | .NET Core 3.1 |    65536 |  7,249.537 ns |   7.6080 ns |   7.1166 ns |  7,246.9133 ns |  0.35 |    0.00 |     - |     - |     - |         - |
|                  |               |               |          |               |             |             |                |       |         |       |       |       |           |
|     Crc32CSseLnL | .NET Core 5.0 | .NET Core 5.0 |    65536 | 20,549.836 ns | 143.4660 ns | 134.1982 ns | 20,527.3048 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|     Crc32CSsePet | .NET Core 5.0 | .NET Core 5.0 |    65536 |  7,248.512 ns |   6.1218 ns |   5.4268 ns |  7,250.3782 ns |  0.35 |    0.00 |     - |     - |     - |         - |