### PR TITLE
Feature/packet layer endpoint

### DIFF
--- a/LibSample/AesEncryptLayer.cs
+++ b/LibSample/AesEncryptLayer.cs
@@ -50,17 +50,19 @@ namespace LibSample
         public override void ProcessInboundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
         {
             //Can't copy directly to _aes.IV. It won't work for some reason.
-            Buffer.BlockCopy(data, 0, ivBuffer, 0, ivBuffer.Length);
+            Buffer.BlockCopy(data, offset, ivBuffer, 0, ivBuffer.Length);
             //_aes.IV = ivBuffer;
             _decryptor = _aes.CreateDecryptor(_aes.Key, ivBuffer);
+            offset += BlockSizeInBytes;
 
             //int currentRead = ivBuffer.Length;
             //int currentWrite = 0;
 
             //TransformBlocks(_decryptor, data, length, ref currentRead, ref currentWrite);
-            byte[] lastBytes = _decryptor.TransformFinalBlock(data, BlockSizeInBytes, length - BlockSizeInBytes);
+            byte[] lastBytes = _decryptor.TransformFinalBlock(data, offset, length - offset);
 
             data = lastBytes;
+            offset = 0;
             length = lastBytes.Length;
         }
 

--- a/LibSample/AesEncryptLayer.cs
+++ b/LibSample/AesEncryptLayer.cs
@@ -1,5 +1,6 @@
 ﻿using LiteNetLib.Layers;
 using System;
+using System.Net;
 using System.Security.Cryptography;
 
 namespace LibSample
@@ -46,7 +47,7 @@ namespace LibSample
             _decryptor = _aes.CreateDecryptor();
         }
 
-        public override void ProcessInboundPacket(ref byte[] data, ref int length)
+        public override void ProcessInboundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
         {
             //Can't copy directly to _aes.IV. It won't work for some reason.
             Buffer.BlockCopy(data, 0, ivBuffer, 0, ivBuffer.Length);
@@ -63,7 +64,7 @@ namespace LibSample
             length = lastBytes.Length;
         }
 
-        public override void ProcessOutBoundPacket(ref byte[] data, ref int offset, ref int length)
+        public override void ProcessOutBoundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
         {
             //Some Unity platforms may need these (and will be slower + generate garbage)
             if (!_encryptor.CanReuseTransform)

--- a/LibSample/AesEncryptionTest.cs
+++ b/LibSample/AesEncryptionTest.cs
@@ -21,7 +21,7 @@ namespace LibSample
             int lengthOfPacket = outbound.Length;
             int start = 0;
             int length = outbound.Length;
-            outboudLayer.ProcessOutBoundPacket(ref outbound, ref start, ref length);
+            outboudLayer.ProcessOutBoundPacket(null, ref outbound, ref start, ref length);
 
             int minLenth = lengthOfPacket + AesEncryptLayer.BlockSizeInBytes;
             int maxLength = lengthOfPacket + outboudLayer.ExtraPacketSizeForLayer;
@@ -34,7 +34,7 @@ namespace LibSample
             //Copy array so we dont read and write to same array
             byte[] inboundData = new byte[outbound.Length];
             outbound.CopyTo(inboundData, 0);
-            inboundLayer.ProcessInboundPacket(ref inboundData, ref length);
+            inboundLayer.ProcessInboundPacket(null, ref inboundData, ref start, ref length);
 
             Console.WriteLine(Encoding.ASCII.GetString(inboundData, 0, length));
             byte[] expectedPlaintext = Encoding.ASCII.GetBytes(testData);

--- a/LiteNetLib/Layers/Crc32cLayer.cs
+++ b/LiteNetLib/Layers/Crc32cLayer.cs
@@ -20,7 +20,7 @@ namespace LiteNetLib.Layers
             }
 
             int checksumPoint = length - CRC32C.ChecksumSize;
-            if (CRC32C.Compute(data, 0, checksumPoint) != BitConverter.ToUInt32(data, checksumPoint))
+            if (CRC32C.Compute(data, offset, checksumPoint) != BitConverter.ToUInt32(data, checksumPoint))
             {
                 NetDebug.Write("[NM] DataReceived checksum: bad!");
                 return;

--- a/LiteNetLib/Layers/Crc32cLayer.cs
+++ b/LiteNetLib/Layers/Crc32cLayer.cs
@@ -1,5 +1,6 @@
 ﻿using LiteNetLib.Utils;
 using System;
+using System.Net;
 
 namespace LiteNetLib.Layers
 {
@@ -10,7 +11,7 @@ namespace LiteNetLib.Layers
 
         }
 
-        public override void ProcessInboundPacket(ref byte[] data, ref int length)
+        public override void ProcessInboundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
         {
             if (length < NetConstants.HeaderSize + CRC32C.ChecksumSize)
             {
@@ -27,7 +28,7 @@ namespace LiteNetLib.Layers
             length -= CRC32C.ChecksumSize;
         }
 
-        public override void ProcessOutBoundPacket(ref byte[] data, ref int offset, ref int length)
+        public override void ProcessOutBoundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
         {
             FastBitConverter.GetBytes(data, length, CRC32C.Compute(data, offset, length));
             length += CRC32C.ChecksumSize;

--- a/LiteNetLib/Layers/PacketLayerBase.cs
+++ b/LiteNetLib/Layers/PacketLayerBase.cs
@@ -1,4 +1,6 @@
-﻿namespace LiteNetLib.Layers
+﻿using System.Net;
+
+namespace LiteNetLib.Layers
 {
     public abstract class PacketLayerBase
     {
@@ -9,7 +11,7 @@
             ExtraPacketSizeForLayer = extraPacketSizeForLayer;
         }
 
-        public abstract void ProcessInboundPacket(ref byte[] data, ref int length);
-        public abstract void ProcessOutBoundPacket(ref byte[] data, ref int offset, ref int length);
+        public abstract void ProcessInboundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length);
+        public abstract void ProcessOutBoundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length);
     }
 }

--- a/LiteNetLib/Layers/XorEncryptLayer.cs
+++ b/LiteNetLib/Layers/XorEncryptLayer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Text;
 
 namespace LiteNetLib.Layers
@@ -34,18 +35,18 @@ namespace LiteNetLib.Layers
             Buffer.BlockCopy(key, 0, _byteKey, 0, key.Length);
         }
 
-        public override void ProcessInboundPacket(ref byte[] data, ref int length)
+        public override void ProcessInboundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
         {
             if (_byteKey == null)
                 return;
-            for (var i = 0; i < length; i++)
+            var cur = offset;
+            for (var i = 0; i < length; i++, cur++)
             {
-                var offset = i % _byteKey.Length;
-                data[i] = (byte)(data[i] ^ _byteKey[offset]);
+                data[cur] = (byte)(data[cur] ^ _byteKey[i % _byteKey.Length]);
             }
         }
 
-        public override void ProcessOutBoundPacket(ref byte[] data, ref int offset, ref int length)
+        public override void ProcessOutBoundPacket(IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
         {
             if (_byteKey == null)
                 return;


### PR DESCRIPTION
Modified PacketLayerBase so that ProcessInboundPacket and ProcessOutboundPacket are both given the IPEndPoint of the sender/receiver, which is necessary for encryption layers that require per-connection state. 

I also added `ref offset` to ProcessInboundPacket to be consistent with ProcessOutboundPacket. This is useful in the case that some data is prefixed to the message. In the example of encryption, the IV will be placed in the first N bytes, and the encrypted message after that. Because the offset can be moved to the position after the IV, if the message can be decrypted in place, it can be returned without a copy.