### PR TITLE
NetStatistics thread safety

### DIFF
--- a/LibSample/SpeedBench.cs
+++ b/LibSample/SpeedBench.cs
@@ -17,6 +17,11 @@ namespace LibSample
 
             readonly NetManager _server;
 
+            public NetStatistics Stats
+            {
+                get { return _server.Statistics; }
+            }
+
             public Server()
             {
                 _server = new NetManager(this);
@@ -24,6 +29,7 @@ namespace LibSample
                 _server.UpdateTime = 1;
                 _server.SimulatePacketLoss = false;
                 _server.SimulationPacketLossChance = 20;
+                _server.EnableStatistics = true;
                 _server.Start(9050);
             }
 
@@ -104,6 +110,7 @@ namespace LibSample
                 _client.AutoRecycle = true;
                 _client.SimulatePacketLoss = false;
                 _client.SimulationPacketLossChance = 20;
+                _client.EnableStatistics = true;
                 _client.Start();
             }
 
@@ -200,6 +207,7 @@ namespace LibSample
                 Thread.Sleep(10000);
                 s.PollEvents();
                 Console.WriteLine("SERVER RECEIVED -> Reliable: " + s.ReliableReceived + ", Unreliable: " + s.UnreliableReceived);
+                Console.WriteLine("SERVER STATS:\n" + s.Stats);
             }
         }
 

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -497,8 +497,8 @@ namespace LiteNetLib
 
             if (EnableStatistics)
             {
-                Statistics.PacketsSent++;
-                Statistics.BytesSent += (uint)length;
+                Statistics.IncrementPacketsSent();
+                Statistics.AddBytesSent(length);
             }
 
             return result;
@@ -675,8 +675,6 @@ namespace LiteNetLib
                 }
 #endif
 
-                ulong totalPacketLoss = 0;
-
                 int elapsed = (int)stopwatch.ElapsedMilliseconds;
                 elapsed = elapsed <= 0 ? 1 : elapsed;
                 stopwatch.Reset();
@@ -691,11 +689,6 @@ namespace LiteNetLib
                     else
                     {
                         netPeer.Update(elapsed);
-
-                        if (EnableStatistics)
-                        {
-                            totalPacketLoss += netPeer.Statistics.PacketLoss;
-                        }
                     }
                 }
                 if (peersToRemove.Count > 0)
@@ -705,11 +698,6 @@ namespace LiteNetLib
                         RemovePeerInternal(peersToRemove[i]);
                     _peersLock.ExitWriteLock();
                     peersToRemove.Clear();
-                }
-
-                if (EnableStatistics)
-                {
-                    Statistics.PacketLoss = totalPacketLoss;
                 }
 
                 int sleepTime = UpdateTime - (int)stopwatch.ElapsedMilliseconds;
@@ -897,8 +885,8 @@ namespace LiteNetLib
         {
             if (EnableStatistics)
             {
-                Statistics.PacketsReceived++;
-                Statistics.BytesReceived += (uint)count;
+                Statistics.IncrementPacketsReceived();
+                Statistics.AddBytesReceived(count);
             }
 
             if (_extraPacketLayer != null)

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -989,8 +989,8 @@ namespace LiteNetLib
 
             if (NetManager.EnableStatistics)
             {
-                Statistics.PacketsSent++;
-                Statistics.BytesSent += (ulong)bytesSent;
+                Statistics.IncrementPacketsSent();
+                Statistics.AddBytesSent(bytesSent);
             }
 
             _mergePos = 0;
@@ -1009,8 +1009,8 @@ namespace LiteNetLib
 
                 if (NetManager.EnableStatistics)
                 {
-                    Statistics.PacketsSent++;
-                    Statistics.BytesSent += (ulong)bytesSent;
+                    Statistics.IncrementPacketsSent();
+                    Statistics.AddBytesSent(bytesSent);
                 }
 
                 return;

--- a/LiteNetLib/NetStatistics.cs
+++ b/LiteNetLib/NetStatistics.cs
@@ -1,28 +1,88 @@
-﻿namespace LiteNetLib
+﻿using System.Threading;
+
+namespace LiteNetLib
 {
-    public sealed class NetStatistics
-    {
-        public ulong PacketsSent;
-        public ulong PacketsReceived;
-        public ulong BytesSent;
-        public ulong BytesReceived;
-        public ulong PacketLoss;
-        public ulong PacketLossPercent
+    public sealed class NetStatistics {
+
+        private long _packetsSent;
+        private long _packetsReceived;
+        private long _bytesSent;
+        private long _bytesReceived;
+        private long _packetLoss;
+
+
+        public long PacketsSent 
         {
-            get { return PacketsSent == 0 ? 0 : PacketLoss * 100 / PacketsSent; }
+            get { return Interlocked.Read(ref _packetsSent); }
         }
 
-        public ulong SequencedPacketLoss;
-
-        public void Reset()
+        public long PacketsReceived 
         {
-            PacketsSent = 0;
-            PacketsReceived = 0;
-            BytesSent = 0;
-            BytesReceived = 0;
-            PacketLoss = 0;
+            get { return Interlocked.Read(ref _packetsReceived); }
         }
 
+        public long BytesSent 
+        { 
+            get { return Interlocked.Read(ref _bytesSent); }
+        }
+        public long BytesReceived 
+        { 
+            get { return Interlocked.Read(ref _bytesReceived); }
+        }
+        public long PacketLoss 
+        { 
+            get { return Interlocked.Read(ref _packetLoss); }
+        }
+        
+        public long PacketLossPercent
+        {
+            get 
+            {
+                long sent = PacketsSent, loss = PacketLoss;
+                
+                return sent == 0 ? 0 : loss * 100 / sent;
+            }
+        }
+
+        public void Reset() 
+        {
+            Interlocked.Exchange(ref _packetsSent, 0);
+            Interlocked.Exchange(ref _packetsReceived, 0);
+            Interlocked.Exchange(ref _bytesSent, 0);
+            Interlocked.Exchange(ref _bytesReceived, 0);
+            Interlocked.Exchange(ref _packetLoss, 0);
+        }
+
+        public void IncrementPacketsSent() 
+        {
+            Interlocked.Increment(ref _packetsSent);
+        }
+
+        public void IncrementPacketsReceived() 
+        {
+            Interlocked.Increment(ref _packetsReceived);
+        }
+
+        public void AddBytesSent(long bytesSent) 
+        {
+            Interlocked.Add(ref _bytesSent, bytesSent);
+        }
+
+        public void AddBytesReceived(long bytesReceived) 
+        {
+            Interlocked.Add(ref _bytesReceived, bytesReceived);
+        }
+
+        public void IncrementPacketLoss() 
+        {
+            Interlocked.Increment(ref _packetLoss);
+        }
+
+        public void AddPacketLoss(long packetLoss) 
+        {
+            Interlocked.Add(ref _packetLoss, packetLoss);
+        }
+        
         public override string ToString()
         {
             return

--- a/LiteNetLib/ReliableChannel.cs
+++ b/LiteNetLib/ReliableChannel.cs
@@ -138,14 +138,11 @@ namespace LiteNetLib
                     int currentBit = pendingIdx % BitsInByte;
                     if ((acksData[currentByte] & (1 << currentBit)) == 0)
                     {
-#if DEBUG
-                        Peer.Statistics.PacketLoss++;
-#else
                         if (Peer.NetManager.EnableStatistics) 
                         {
-                            Peer.Statistics.PacketLoss++;
+                            Peer.Statistics.IncrementPacketLoss();
+                            Peer.NetManager.Statistics.IncrementPacketLoss();
                         }
-#endif
 
                         //Skip false ack
                         NetDebug.Write("[PA]False ack: {0}", pendingSeq);

--- a/LiteNetLib/SequencedChannel.cs
+++ b/LiteNetLib/SequencedChannel.cs
@@ -83,7 +83,12 @@ namespace LiteNetLib
             bool packetProcessed = false;
             if (packet.Sequence < NetConstants.MaxSequence && relative > 0)
             {
-                Peer.Statistics.PacketLoss += (ulong)(relative - 1);
+                if (Peer.NetManager.EnableStatistics) 
+                {
+                    Peer.Statistics.AddPacketLoss(relative - 1);
+                    Peer.NetManager.Statistics.AddPacketLoss(relative - 1);
+                }
+
                 _remoteSequence = packet.Sequence;
                 Peer.NetManager.CreateReceiveEvent(
                     packet, 


### PR DESCRIPTION
According to C# spec, ulong is not necessarily atomic (see https://stackoverflow.com/questions/11745440/what-operations-are-atomic-in-c). Therefore, NetStatistics cannot safely be used from a different thread than it is written to. PacketsReceived and BytesReceived are updated on the ReceiveLogic thread, PacketsSent, BytesSent, and PacketLoss are updated on the UpdateLogic thread, and Statistics are presumably read or Reset on the main thread by the application, (though technically the application could read and write them from any thread, since they are public). 

To avoid thread safety issues, I've changed the type to long and modified the access of these values to all use Interlocked. I also removed the #if DEBUG block in ReliableChannel (since it is inconsistent with other usages of StatisticsEnabled), and wrapped the update of PacketLoss in SequencedChannel with `if (StatisticsEnabled)`.

The other major change is the PacketLoss statistic is no longer set to the sum of all currently connected NetPeers (which resulted in the value decrementing on the removal of a peer, causing the PacketLossPercent to be inaccurate in a situation with regular connection and disconnection events), and instead simply increment it whenever the value for each peer is updated.