### PR TITLE
MTU Override & Raise Options

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -179,6 +179,7 @@ namespace LiteNetLib
         private byte _channelsCount = 1;
 
         internal int mtuOverride = 0;
+        internal bool mtuInitialRaise = false;
 
         internal readonly NetPacketPool NetPacketPool;
 
@@ -1085,12 +1086,20 @@ namespace LiteNetLib
         }
 
         /// <summary>
-        /// Override MTU for all new peers registered in this NetManager
+        /// Override MTU for all new peers registered in this NetManager, will ignores MTU Discovery!
         /// </summary>
         /// <param name="value">value to use for all new peers</param>
         public void OverrideMTU(int value)
         {
             mtuOverride = value;
+        }
+
+        /// <summary>
+        /// Raises Initial MTU of new peers to 1,164 bytes instead of 508 bytes
+        /// </summary>
+        public void RaiseInitialMTU()
+        {
+            mtuInitialRaise = true;
         }
 
         /// <summary>

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -178,6 +178,8 @@ namespace LiteNetLib
         private readonly Queue<int> _peerIds;
         private byte _channelsCount = 1;
 
+        internal int mtuOverride = 0;
+
         internal readonly NetPacketPool NetPacketPool;
 
         //config section
@@ -1080,6 +1082,15 @@ namespace LiteNetLib
                 lock (_netEventsQueue)
                     _netEventsQueue.Enqueue(evt);
             }
+        }
+
+        /// <summary>
+        /// Override MTU for all new peers registered in this NetManager
+        /// </summary>
+        /// <param name="value">value to use for all new peers</param>
+        public void OverrideMTU(int value)
+        {
+            mtuOverride = value;
         }
 
         /// <summary>

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -202,7 +202,11 @@ namespace LiteNetLib
             Statistics = new NetStatistics();
             _packetPool = netManager.NetPacketPool;
             NetManager = netManager;
-            SetMtu(0);
+
+            if (netManager.mtuOverride > 0)
+                OverrideMTU(netManager.mtuOverride);
+            else
+                SetMtu(0);
 
             EndPoint = remoteEndPoint;
             _connectionState = ConnectionState.Connected;
@@ -221,6 +225,16 @@ namespace LiteNetLib
         private void SetMtu(int mtuIdx)
         {
             _mtu = NetConstants.PossibleMtu[mtuIdx] - NetManager.ExtraPacketSizeForLayer;
+        }
+
+        /// <summary>
+        /// Overrides MTU with specificed value
+        /// </summary>
+        /// <param name="value">value of overriden mtu</param>
+        public void OverrideMTU(int value)
+        {
+            _mtu = value;
+            _finishMtu = true;
         }
 
         /// <summary>

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -205,6 +205,8 @@ namespace LiteNetLib
 
             if (netManager.mtuOverride > 0)
                 OverrideMTU(netManager.mtuOverride);
+            else if (netManager.mtuInitialRaise)
+                SetMtu(1);
             else
                 SetMtu(0);
 
@@ -227,13 +229,9 @@ namespace LiteNetLib
             _mtu = NetConstants.PossibleMtu[mtuIdx] - NetManager.ExtraPacketSizeForLayer;
         }
 
-        /// <summary>
-        /// Overrides MTU with specificed value
-        /// </summary>
-        /// <param name="value">value of overriden mtu</param>
-        public void OverrideMTU(int value)
+        private void OverrideMTU(int mtuValue)
         {
-            _mtu = value;
+            _mtu = mtuValue;
             _finishMtu = true;
         }
 


### PR DESCRIPTION
Adding options to override & raise MTU, the override will ignore MTU discovery while the raise will only raise the MTU one rank to 1232 - MaxUdpHeaderSize.
Thought these would be helpful since the MTU gets set to a very low minimum of ~500B before MTU discovery.