### PR TITLE
FIX CRC32Layer should drop packets with bad checksum

### DIFF
--- a/LiteNetLib.Tests/CRC32LayerTest.cs
+++ b/LiteNetLib.Tests/CRC32LayerTest.cs
@@ -15,6 +15,7 @@ namespace LiteNetLib.Tests
         [SetUp]
         public void Setup()
         {
+            NetDebug.Logger = null;
             _crc32Layer = new Crc32cLayer();
             _dummyEndpoint = new IPEndPoint(IPAddress.Loopback, 23456);
         }
@@ -53,6 +54,7 @@ namespace LiteNetLib.Tests
 
             int offset = 0;
             int length = packet.Length;
+
             _crc32Layer.ProcessInboundPacket(_dummyEndpoint, ref packet, ref offset, ref length);
 
             Assert.AreEqual(0, length);

--- a/LiteNetLib.Tests/CRC32LayerTest.cs
+++ b/LiteNetLib.Tests/CRC32LayerTest.cs
@@ -1,0 +1,90 @@
+﻿using LiteNetLib.Layers;
+using LiteNetLib.Utils;
+using NUnit.Framework;
+using System;
+using System.Net;
+
+namespace LiteNetLib.Tests
+{
+    [TestFixture]
+    public class CRC32LayerTest
+    {
+        private Crc32cLayer _crc32Layer;
+        private IPEndPoint _dummyEndpoint;
+
+        [SetUp]
+        public void Setup()
+        {
+            _crc32Layer = new Crc32cLayer();
+            _dummyEndpoint = new IPEndPoint(IPAddress.Loopback, 23456);
+        }
+
+        [Test]
+        public void ReturnsDataWithoutChecksum()
+        {
+            byte[] packet = GetTestPacketWithCrc();
+
+            int offset = 0;
+            int length = packet.Length;
+            _crc32Layer.ProcessInboundPacket(_dummyEndpoint, ref packet, ref offset, ref length);
+
+            Assert.AreEqual(packet.Length - CRC32C.ChecksumSize, length);
+        }
+
+        [Test]
+        public void ReturnsNilCountForBadChecksum()
+        {
+            byte[] packet = GetTestPacketWithCrc();
+
+            //Fake a change to the data to cause data/crc missmatch
+            packet[4] = 0;
+
+            int offset = 0;
+            int length = packet.Length;
+            _crc32Layer.ProcessInboundPacket(_dummyEndpoint, ref packet, ref offset, ref length);
+
+            Assert.AreEqual(0, length);
+        }
+
+        [Test]
+        public void ReturnsNilCountForTooShortMessage()
+        {
+            byte[] packet = new byte[2];
+
+            int offset = 0;
+            int length = packet.Length;
+            _crc32Layer.ProcessInboundPacket(_dummyEndpoint, ref packet, ref offset, ref length);
+
+            Assert.AreEqual(0, length);
+        }
+
+        [Test]
+        public void CanSendAndReceiveSameMessage()
+        {
+            byte[] message = GetTestMessageBytes();
+            //Process outbound adds bytes, so we need a larger array
+            byte[] package = new byte[message.Length + CRC32C.ChecksumSize];
+
+            Buffer.BlockCopy(message, 0, package, 0, message.Length);
+
+            int offset = 0;
+            int length = message.Length;
+            _crc32Layer.ProcessOutBoundPacket(_dummyEndpoint, ref package, ref offset, ref length);
+            _crc32Layer.ProcessInboundPacket(_dummyEndpoint, ref package, ref offset, ref length);
+        }
+
+        private static byte[] GetTestPacketWithCrc()
+        {
+            byte[] testMsg = GetTestMessageBytes();
+            uint crc32 = CRC32C.Compute(testMsg, 0, testMsg.Length);
+
+            byte[] packet = new byte[testMsg.Length + CRC32C.ChecksumSize];
+            Buffer.BlockCopy(testMsg, 0, packet, 0, testMsg.Length);
+            FastBitConverter.GetBytes(packet, testMsg.Length, crc32);
+            return packet;
+        }
+
+        private static byte[] GetTestMessageBytes()
+            => System.Text.Encoding.ASCII.GetBytes("This is a test string with some length");
+    }
+}

--- a/LiteNetLib.Tests/CommunicationTest.cs
+++ b/LiteNetLib.Tests/CommunicationTest.cs
@@ -662,7 +662,7 @@ namespace LiteNetLib.Tests
         public void ManualMode()
         {
             var serverListener = new EventBasedNetListener();
-            var server = new NetManager(serverListener);
+            var server = new NetManager(serverListener, new Crc32cLayer());
 
             serverListener.ConnectionRequestEvent += request => request.AcceptIfKey(DefaultAppKey);
 

--- a/LiteNetLib/Layers/Crc32cLayer.cs
+++ b/LiteNetLib/Layers/Crc32cLayer.cs
@@ -16,6 +16,8 @@ namespace LiteNetLib.Layers
             if (length < NetConstants.HeaderSize + CRC32C.ChecksumSize)
             {
                 NetDebug.WriteError("[NM] DataReceived size: bad!");
+                //Set length to 0 to have netManager drop the packet.
+                length = 0;
                 return;
             }
 
@@ -23,6 +25,8 @@ namespace LiteNetLib.Layers
             if (CRC32C.Compute(data, offset, checksumPoint) != BitConverter.ToUInt32(data, checksumPoint))
             {
                 NetDebug.Write("[NM] DataReceived checksum: bad!");
+                //Set length to 0 to have netManager drop the packet.
+                length = 0;
                 return;
             }
             length -= CRC32C.ChecksumSize;


### PR DESCRIPTION
After the move of CRC to separate layer the actual dropping of bad messages broke.