### PR TITLE
Use new _OR_GREATER defines

### DIFF
--- a/LiteNetLib/Utils/CRC32C.cs
+++ b/LiteNetLib/Utils/CRC32C.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_1
+﻿#if NETCOREAPP3_0_OR_GREATER || NETCOREAPP3_1
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
@@ -15,7 +15,7 @@ namespace LiteNetLib.Utils
 
         static CRC32C()
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_0_OR_GREATER || NETCOREAPP3_1
             if(Sse42.IsSupported)
                 return;
 #endif
@@ -42,7 +42,7 @@ namespace LiteNetLib.Utils
         public static uint Compute(byte[] input, int offset, int length)
         {
             uint crcLocal = uint.MaxValue;
-#if NETCOREAPP3_1
+#if NETCOREAPP3_0_OR_GREATER || NETCOREAPP3_1
             if (Sse42.IsSupported)
             {
                 var data = new ReadOnlySpan<byte>(input, offset, length);


### PR DESCRIPTION
.Net 5.0.200 SDK added support for using _OR_GREATER with runtime version defines, no reason not to use them. Old defines aren't removed since old SDKs don't support this.

Documentation: https://github.com/dotnet/designs/blob/main/accepted/2020/or-greater-defines/or-greater-defines.md