### PR TITLE
Use POH for permanent arrays

### DIFF
--- a/LiteNetLib/NetPacket.cs
+++ b/LiteNetLib/NetPacket.cs
@@ -33,7 +33,11 @@ namespace LiteNetLib
 
         static NetPacket()
         {
-            HeaderSizes = new int[LastProperty+1];
+#if NET5_0_OR_GREATER || NET5_0
+            HeaderSizes = GC.AllocateUninitializedArray<int>(LastProperty + 1, true);
+#else
+            HeaderSizes = new int[LastProperty + 1];
+#endif
             for (int i = 0; i < HeaderSizes.Length; i++)
             {
                 switch ((PacketProperty)i)

--- a/LiteNetLib/Utils/CRC32C.cs
+++ b/LiteNetLib/Utils/CRC32C.cs
@@ -26,7 +26,11 @@ namespace LiteNetLib.Utils
             if (Crc32.IsSupported)
                 return;
 #endif
+#if NET5_0_OR_GREATER || NET5_0
+            Table = GC.AllocateUninitializedArray<uint>(16 * 256, true);
+#else
             Table = new uint[16 * 256];
+#endif
             for (uint i = 0; i < 256; i++)
             {
                 uint res = i;


### PR DESCRIPTION
Keeping them in the POH reduces the amount of memory that's moved by the GC, since they're static it's safe to put them there.