### PR TITLE
Add an asmdef for Unity

### DIFF
--- a/LiteNetLib/LiteNetLib.asmdef
+++ b/LiteNetLib/LiteNetLib.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "LiteNetLib",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}


### PR DESCRIPTION
This enables unsafe code in every supported Unity version and optimizes compilation to not recompile LiteNetLib every time.