### PR TITLE
Blocking mode support for pollevents

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -1519,10 +1519,13 @@ namespace LiteNetLib
             }
             else
             {
-                _canPoll.WaitOne();
-                while(_netEventsQueue.TryDequeue(out var evt))
+                while (BlockingPoll)
                 {
-                    ProcessEvent(evt);
+                    _canPoll.WaitOne();
+                    while (_netEventsQueue.TryDequeue(out var evt))
+                    {
+                        ProcessEvent(evt);
+                    }
                 }
             }
         }


### PR DESCRIPTION
It's a cleaner approach to continuously process the events for server.
For a high loaded server, we do not have to make the thread sleep when it shouldn't
For a low loaded server, where Thread Sleep is set to 15ms or similar, this will prevent possible scenarios where packets wait for the same duration without any additional performance penalty

In other words: If packets are sent every 1ms, this will ensure that the packets processed every 1ms aswell. If packets are sent every 15ms, then also this will ensure that the packets will be processed at the same interval. If no packets are received, then the poll thread will remain blocked.