### PR TITLE
Improve NetDataWriter speed

### DIFF
--- a/LiteNetLib/Utils/FastBitConverter.cs
+++ b/LiteNetLib/Utils/FastBitConverter.cs
@@ -11,12 +11,12 @@ namespace LiteNetLib.Utils
         public static unsafe void GetBytes<T>(byte[] bytes, int startIndex, T value) where T : unmanaged
         {
             if (bytes.Length < startIndex + sizeof(T))
-                ThrowArgumentOutOfRangeException();
+                ThrowIndexOutOfRangeException();
             fixed (byte* ptr = &bytes[startIndex])
                 *(T*)ptr = value;
         }
 
-        private static void ThrowArgumentOutOfRangeException() => throw new IndexOutOfRangeException();
+        private static void ThrowIndexOutOfRangeException() => throw new IndexOutOfRangeException();
 #else
         [StructLayout(LayoutKind.Explicit)]
         private struct ConverterHelperDouble

--- a/LiteNetLib/Utils/FastBitConverter.cs
+++ b/LiteNetLib/Utils/FastBitConverter.cs
@@ -1,9 +1,23 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace LiteNetLib.Utils
 {
     public static class FastBitConverter
     {
+#if LITENETLIB_UNSAFE && !BIGENDIAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void GetBytes<T>(byte[] bytes, int startIndex, T value) where T : unmanaged
+        {
+            if (bytes.Length < startIndex + sizeof(T))
+                ThrowArgumentOutOfRangeException();
+            fixed (byte* ptr = &bytes[startIndex])
+                *(T*)ptr = value;
+        }
+
+        private static void ThrowArgumentOutOfRangeException() => throw new IndexOutOfRangeException();
+#else
         [StructLayout(LayoutKind.Explicit)]
         private struct ConverterHelperDouble
         {
@@ -24,6 +38,7 @@ namespace LiteNetLib.Utils
             public float Afloat;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void WriteLittleEndian(byte[] buffer, int offset, ulong data)
         {
 #if BIGENDIAN
@@ -47,6 +62,7 @@ namespace LiteNetLib.Utils
 #endif
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void WriteLittleEndian(byte[] buffer, int offset, int data)
         {
 #if BIGENDIAN
@@ -62,6 +78,7 @@ namespace LiteNetLib.Utils
 #endif
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteLittleEndian(byte[] buffer, int offset, short data)
         {
 #if BIGENDIAN
@@ -73,46 +90,55 @@ namespace LiteNetLib.Utils
 #endif
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, double value)
         {
             ConverterHelperDouble ch = new ConverterHelperDouble { Adouble = value };
             WriteLittleEndian(bytes, startIndex, ch.Along);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, float value)
         {
             ConverterHelperFloat ch = new ConverterHelperFloat { Afloat = value };
             WriteLittleEndian(bytes, startIndex, ch.Aint);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, short value)
         {
             WriteLittleEndian(bytes, startIndex, value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, ushort value)
         {
             WriteLittleEndian(bytes, startIndex, (short)value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, int value)
         {
             WriteLittleEndian(bytes, startIndex, value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, uint value)
         {
             WriteLittleEndian(bytes, startIndex, (int)value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, long value)
         {
             WriteLittleEndian(bytes, startIndex, (ulong)value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void GetBytes(byte[] bytes, int startIndex, ulong value)
         {
             WriteLittleEndian(bytes, startIndex, value);
         }
+#endif
     }
 }

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace LiteNetLib.Utils
@@ -65,15 +66,22 @@ namespace LiteNetLib.Utils
             return netDataWriter;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResizeIfNeed(int newSize)
         {
-            int len = _data.Length;
-            if (len < newSize)
+            if (_data.Length < newSize)
             {
-                while (len < newSize)
-                    len *= 2;
-                Array.Resize(ref _data, len);
+                Resize(newSize);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Resize(int newSize)
+        {
+            int len = _data.Length;
+            while (len < newSize)
+                len *= 2;
+            Array.Resize(ref _data, len);
         }
 
         public void Reset(int size)


### PR DESCRIPTION
Benchmark says it takes 50% less time when writing a double and 30% less time when writing an int.

Used unsafe for writing, added AggressiveInlining since the JIT ASM had no inlining at all without it.