### PR TITLE
Remove Sync-Over-Async within ResolveAddresses()

### DIFF
--- a/LiteNetLib/NetUtils.cs
+++ b/LiteNetLib/NetUtils.cs
@@ -61,10 +61,7 @@ namespace LiteNetLib
 
         public static IPAddress[] ResolveAddresses(string hostStr)
         {
-            var hostTask = Dns.GetHostEntryAsync(hostStr);
-            hostTask.GetAwaiter().GetResult();
-            var host = hostTask.Result;
-            return host.AddressList;
+            return Dns.GetHostEntry(hostStr).AddressList;
         }
 
         /// <summary>


### PR DESCRIPTION
Calling async code from synchronous methods and simply blocking on the returned task has unnecessary overheads compared to just calling the synchronous overloads.

Switches ResolveAddresses() to use the synchronous version of `Dns.GetHostEntry()`