### PR TITLE
Add channel to the OnNetworkReceive event

### DIFF
--- a/LibSample/BroadcastTest.cs
+++ b/LibSample/BroadcastTest.cs
@@ -28,7 +28,7 @@ namespace LibSample
                 Console.WriteLine("[Client] error! " + error);
             }
 
-            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel)
+            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channel, DeliveryMethod deliveryMethod)
             {
 
             }
@@ -78,7 +78,7 @@ namespace LibSample
                 Console.WriteLine("[Server] error: " + socketErrorCode);
             }
 
-            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel)
+            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
             {
 
             }

--- a/LibSample/EchoMessagesTest.cs
+++ b/LibSample/EchoMessagesTest.cs
@@ -63,7 +63,7 @@ namespace LibSample
                 Console.WriteLine("[Client] error! " + socketErrorCode);
             }
 
-            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel)
+            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
             {
                 if (reader.AvailableBytes == 13218)
                 {
@@ -121,7 +121,7 @@ namespace LibSample
                 Console.WriteLine("[Server] error: " + socketErrorCode);
             }
 
-            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel)
+            public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
             {
                 //echo
                 peer.Send(reader.GetRemainingBytes(), deliveryMethod);

--- a/LibSample/GithubSample.cs
+++ b/LibSample/GithubSample.cs
@@ -44,7 +44,7 @@ namespace LibSample
             NetManager client = new NetManager(listener);
             client.Start();
             client.Connect("localhost" /* host ip or name */, 9050 /* port */, "SomeConnectionKey" /* text key or NetDataWriter */);
-            listener.NetworkReceiveEvent += (fromPeer, dataReader, deliveryMethod, channel) =>
+            listener.NetworkReceiveEvent += (fromPeer, dataReader, channel, deliveryMethod) =>
             {
                 Console.WriteLine("We got: {0}", dataReader.GetString(100 /* max length of string */));
                 dataReader.Recycle();

--- a/LibSample/PacketProcessorExample.cs
+++ b/LibSample/PacketProcessorExample.cs
@@ -52,7 +52,7 @@ namespace LibSample
                 request.AcceptIfKey("key");
             };
             serverListener.NetworkReceiveEvent +=
-                (peer, reader, method, channel) =>
+                (peer, reader, channel, method) =>
                 {
                     _netPacketProcessor.ReadAllPackets(reader, peer);
                 };

--- a/LibSample/SpeedBench.cs
+++ b/LibSample/SpeedBench.cs
@@ -47,7 +47,7 @@ namespace LibSample
                 request.AcceptIfKey("ConnKey");
             }
 
-            void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel)
+            void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
             {
                 var isReliable = reader.GetBool();
                 var data = reader.GetString();
@@ -146,7 +146,7 @@ namespace LibSample
                 request.RejectForce();
             }
 
-            void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel)
+            void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
             {
 
             }

--- a/LiteNetLib.Tests/CommunicationTest.cs
+++ b/LiteNetLib.Tests/CommunicationTest.cs
@@ -120,7 +120,7 @@ namespace LiteNetLib.Tests
                 arr[testSize - 1] = 254;
                 peer.SendWithDeliveryEvent(arr, 0, DeliveryMethod.ReliableUnordered, testData);
             };
-            ManagerStack.ServerListener(1).NetworkReceiveEvent += (peer, reader, method, channel) =>
+            ManagerStack.ServerListener(1).NetworkReceiveEvent += (peer, reader, channel, method) =>
             {
                 Assert.AreEqual(testSize, reader.UserDataSize);
                 Assert.AreEqual(196, reader.RawData[reader.UserDataOffset]);
@@ -557,7 +557,7 @@ namespace LiteNetLib.Tests
                     }
                 }
             };
-            ManagerStack.ServerListener(1).NetworkReceiveEvent += (peer, reader, method, channel) =>
+            ManagerStack.ServerListener(1).NetworkReceiveEvent += (peer, reader, channel, method) =>
             {
                 Assert.AreEqual((DeliveryMethod)reader.GetByte(), method);
                 messagesReceived++;
@@ -708,7 +708,7 @@ namespace LiteNetLib.Tests
             var dataStack = new Stack<byte[]>(clientCount);
 
             ManagerStack.ClientForeach(
-                (i, manager, l) => l.NetworkReceiveEvent += (peer, reader, type, channel) => dataStack.Push(reader.GetRemainingBytes()));
+                (i, manager, l) => l.NetworkReceiveEvent += (peer, reader, channel, type) => dataStack.Push(reader.GetRemainingBytes()));
 
             var data = Encoding.Default.GetBytes("TextForTest");
             server.SendToAll(data, DeliveryMethod.ReliableUnordered);

--- a/LiteNetLib/INetEventListener.cs
+++ b/LiteNetLib/INetEventListener.cs
@@ -80,7 +80,7 @@ namespace LiteNetLib
         /// <param name="peer">From peer</param>
         /// <param name="reader">DataReader containing all received data</param>
         /// <param name="deliveryMethod">Type of received packet</param>
-        void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel);
+        void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod);
 
         /// <summary>
         /// Received unconnected message
@@ -128,7 +128,7 @@ namespace LiteNetLib
         public delegate void OnPeerConnected(NetPeer peer);
         public delegate void OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo);
         public delegate void OnNetworkError(IPEndPoint endPoint, SocketError socketError);
-        public delegate void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel);
+        public delegate void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channel, DeliveryMethod deliveryMethod);
         public delegate void OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType);
         public delegate void OnNetworkLatencyUpdate(NetPeer peer, int latency);
         public delegate void OnConnectionRequest(ConnectionRequest request);
@@ -208,10 +208,10 @@ namespace LiteNetLib
                 NetworkErrorEvent(endPoint, socketErrorCode);
         }
 
-        void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod, byte channel)
+        void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
         {
             if (NetworkReceiveEvent != null)
-                NetworkReceiveEvent(peer, reader, deliveryMethod, channel);
+                NetworkReceiveEvent(peer, reader, channelNumber, deliveryMethod);
         }
 
         void INetEventListener.OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType)

--- a/LiteNetLib/NetConstants.cs
+++ b/LiteNetLib/NetConstants.cs
@@ -52,6 +52,7 @@
         //protocol
         internal const int ProtocolId = 11;
         internal const int MaxUdpHeaderSize = 68;
+        internal const int ChannelTypeCount = 4;
 
         internal static readonly int[] PossibleMtu =
         {

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -81,7 +81,7 @@ namespace LiteNetLib
         public DisconnectReason DisconnectReason;
         public ConnectionRequest ConnectionRequest;
         public DeliveryMethod DeliveryMethod;
-        public byte Channel;
+        public byte ChannelNumber;
         public readonly NetPacketReader DataReader;
 
         public NetEvent(NetManager manager)
@@ -559,7 +559,7 @@ namespace LiteNetLib
             DisconnectReason disconnectReason = DisconnectReason.ConnectionFailed,
             ConnectionRequest connectionRequest = null,
             DeliveryMethod deliveryMethod = DeliveryMethod.Unreliable,
-            byte channel = 0,
+            byte channelNumber = 0,
             NetPacket readerSource = null,
             object userData = null)
         {
@@ -589,7 +589,7 @@ namespace LiteNetLib
             evt.DisconnectReason = disconnectReason;
             evt.ConnectionRequest = connectionRequest;
             evt.DeliveryMethod = deliveryMethod;
-            evt.Channel = channel;
+            evt.ChannelNumber = channelNumber;
             evt.UserData = userData;
 
             if (unsyncEvent || _manualMode)
@@ -622,7 +622,7 @@ namespace LiteNetLib
                     _netEventListener.OnPeerDisconnected(evt.Peer, info);
                     break;
                 case NetEvent.EType.Receive:
-                    _netEventListener.OnNetworkReceive(evt.Peer, evt.DataReader, evt.DeliveryMethod, evt.Channel);
+                    _netEventListener.OnNetworkReceive(evt.Peer, evt.DataReader, evt.ChannelNumber, evt.DeliveryMethod);
                     break;
                 case NetEvent.EType.ReceiveUnconnected:
                     _netEventListener.OnNetworkReceiveUnconnected(evt.RemoteEndPoint, evt.DataReader, UnconnectedMessageType.BasicMessage);
@@ -1120,7 +1120,7 @@ namespace LiteNetLib
             }
         }
 
-        internal void CreateReceiveEvent(NetPacket packet, DeliveryMethod method, byte channel, int headerSize, NetPeer fromPeer)
+        internal void CreateReceiveEvent(NetPacket packet, DeliveryMethod method, byte channelNumber, int headerSize, NetPeer fromPeer)
         {
             NetEvent evt;
             lock (_eventLock)
@@ -1135,7 +1135,7 @@ namespace LiteNetLib
             evt.DataReader.SetSource(packet, headerSize);
             evt.Peer = fromPeer;
             evt.DeliveryMethod = method;
-            evt.Channel = channel;
+            evt.ChannelNumber = channelNumber;
             if (UnsyncedEvents || UnsyncedReceiveEvent || _manualMode)
             {
                 ProcessEvent(evt);

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -215,7 +215,7 @@ namespace LiteNetLib
             _holdedFragments = new Dictionary<ushort, IncomingFragments>();
             _deliveredFragments = new Dictionary<ushort, ushort>();
 
-            _channels = new BaseChannel[netManager.ChannelsCount * 4];
+            _channels = new BaseChannel[netManager.ChannelsCount * NetConstants.ChannelTypeCount];
             _channelSendQueue = new ConcurrentQueue<BaseChannel>();
         }
 
@@ -239,7 +239,7 @@ namespace LiteNetLib
         /// <returns>packets count in channel queue</returns>
         public int GetPacketsCountInReliableQueue(byte channelNumber, bool ordered)
         {
-            int idx = channelNumber * 4 +
+            int idx = channelNumber * NetConstants.ChannelTypeCount +
                        (byte) (ordered ? DeliveryMethod.ReliableOrdered : DeliveryMethod.ReliableUnordered);
             var channel = _channels[idx];
             return channel != null ? ((ReliableChannel)channel).PacketsInQueue : 0;
@@ -250,7 +250,7 @@ namespace LiteNetLib
             BaseChannel newChannel = _channels[idx];
             if (newChannel != null)
                 return newChannel;
-            switch ((DeliveryMethod)(idx % 4))
+            switch ((DeliveryMethod)(idx % NetConstants.ChannelTypeCount))
             {
                 case DeliveryMethod.ReliableUnordered:
                     newChannel = new ReliableChannel(this, false, idx);
@@ -516,7 +516,7 @@ namespace LiteNetLib
             else
             {
                 property = PacketProperty.Channeled;
-                channel = CreateChannel((byte)(channelNumber*4 + (byte)deliveryMethod));
+                channel = CreateChannel((byte)(channelNumber * NetConstants.ChannelTypeCount + (byte)deliveryMethod));
             }
 
             //Prepare
@@ -655,7 +655,7 @@ namespace LiteNetLib
             else
             {
                 property = PacketProperty.Channeled;
-                channel = CreateChannel((byte)(channelNumber * 4 + (byte)deliveryMethod));
+                channel = CreateChannel((byte)(channelNumber * NetConstants.ChannelTypeCount + (byte)deliveryMethod));
             }
 
             //Prepare
@@ -896,11 +896,11 @@ namespace LiteNetLib
                 _holdedFragments.Remove(packetFragId);
 
                 //Send to process
-                NetManager.CreateReceiveEvent(resultingPacket, method, packetChannelId, 0, this);
+                NetManager.CreateReceiveEvent(resultingPacket, method, (byte)(packetChannelId / NetConstants.ChannelTypeCount), 0, this);
             }
             else //Just simple packet
             {
-                NetManager.CreateReceiveEvent(p, method, p.ChannelId, NetConstants.ChanneledHeaderSize, this);
+                NetManager.CreateReceiveEvent(p, method, (byte)(p.ChannelId / NetConstants.ChannelTypeCount), NetConstants.ChanneledHeaderSize, this);
             }
         }
 

--- a/LiteNetLib/SequencedChannel.cs
+++ b/LiteNetLib/SequencedChannel.cs
@@ -92,7 +92,7 @@ namespace LiteNetLib
                 Peer.NetManager.CreateReceiveEvent(
                     packet,
                     _reliable ? DeliveryMethod.ReliableSequenced : DeliveryMethod.Sequenced,
-                    packet.ChannelId,
+                    (byte)(packet.ChannelId / NetConstants.ChannelTypeCount),
                     NetConstants.ChanneledHeaderSize,
                     Peer);
                 packetProcessed = true;


### PR DESCRIPTION
Hello!

First thanks so much for your hard work on this library! We've been using it for a while with some modifications, but a lot of them have become unnecessary with all the official additions and improvements (the pooling, multiple channels, ignoring some network errors and such)!

I have a situation where I need to know which channel is given message received on, since there are some differences in handling messages from different channels, so I ended up adding this.

I added it in front of DeliveryMethod, so it mimics the order and naming of the Send methods. It seemed like it's idiomatic, although API breaking. I'm not sure if there's a better way to do this that I missed, but hope this helps!