### PR TITLE
Add NetworkReset to ignored errors

### DIFF
--- a/LiteNetLib/NetSocket.cs
+++ b/LiteNetLib/NetSocket.cs
@@ -166,6 +166,7 @@ namespace LiteNetLib
                 case SocketError.ConnectionReset:
                 case SocketError.MessageSize:
                 case SocketError.TimedOut:
+                case SocketError.NetworkReset:
                     //NetDebug.Write($"[R]Ignored error: {(int)ex.SocketErrorCode} - {ex}");
                     break;
                 default:


### PR DESCRIPTION
Hello!

I've added the NetworkReset (WSAENETRESET, 10052) to the list of ignored errors.

This seems generally harmless, it seems to happen for users who have multiple network adapters on their system. Without this they will tend to disconnect when trying to establish a connection, but when it's ignored the networking works fine.