### PR TITLE
Improve method: NetDataReader.GetString(int maxLength)

### DIFF
--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -277,21 +277,8 @@ namespace LiteNetLib.Utils
 
         public string GetString(int maxLength)
         {
-            int bytesCount = GetInt();
-            if (bytesCount <= 0 || bytesCount > maxLength*2)
-            {
-                return string.Empty;
-            }
-
-            int charCount = Encoding.UTF8.GetCharCount(_data, _position, bytesCount);
-            if (charCount > maxLength)
-            {
-                return string.Empty;
-            }
-
-            string result = Encoding.UTF8.GetString(_data, _position, bytesCount);
-            _position += bytesCount;
-            return result;
+            string result = GetString();
+            return result.Length > maxLength ? result.Substring(0, maxLength) : result;
         }
 
         public string GetString()


### PR DESCRIPTION
Deleting checks because:
- `NetDataWriter.Put(string value, int maxLength)` should have put the correct data in the first place.
- Issues with v0.9's `NetDataWriter.Put(string value, int maxLength)` method puts more data than necessary if `value.Length > maxLength`, so this ensures backwards-compatibility. `Put` seems fixed and correct in v1.0.
- Checking against `maxLength*2` is incorrect, since UTF-8 characters can have 3 or 4 bytes, not 2.
- Checking against `charCount` is incorrect if using data that was put from v0.9 if `value.Length` was greater than `maxLength`.
- If the method returns an empty string early, NetDataReader's data position does not increase, which breaks the rest of the reader's data.

Strings I have tested this with when setting `maxLength = 16`:
`植生学硕士—奥尔加·一直卡`
`植生学硕士—奥尔加·一直卡植生学硕士—奥尔加·一直卡`

- In v0.9 and v1.0 (prior to this pull request), neither string gets returned because `bytesCount > maxLength*2` – it would be better to check against `bytesCount > Encoding.UTF8.GetMaxByteCount(maxLength)` if anything.
- For the longer string, further compatibility issues with the old code since v0.9 would have put too much data since `value.Length > maxLength`, and the `charCount` gets messed up due to the unnecessary extra data that was put; the conversion creates a lot of empty blank characters, which increases the `charCount` incorrectly.

With this proposed change, by just calling `GetString()` and truncating the value afterwards, this resolves issues if Put's maxLength is different from GetString's maxLength, and also maintains compatibility with extra unnecessary data put from v0.9.