### PR TITLE
"NetDataReader" & "NetDataWriter"

### DIFF
--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -16,6 +16,13 @@ namespace LiteNetLib.Utils
         public byte[] Data => _data;
         public int Length => _position;
 
+        // Cache encoding instead of creating it with BinaryWriter each time
+        // 1000 readers before: 1MB GC, 30ms
+        // 1000 readers after: .8MB GC, 18ms
+        private static readonly UTF8Encoding _uTF8Encoding = new UTF8Encoding(false, true);
+        public const int StringBufferMaxLength = 1024 * 32; // <- short.MaxValue + 1
+        private static readonly byte[] _stringBuffer = new byte[StringBufferMaxLength];
+
         public NetDataWriter() : this(true, InitialSize)
         {
         }
@@ -329,50 +336,30 @@ namespace LiteNetLib.Utils
             Put(endPoint.Port);
         }
 
-        public void Put(string value)
+        /// <summary>
+        /// Note that "maxLength" only limits the number of characters, not the actual string size. It may be different if you use non-ASCII characters, etc.
+        /// </summary>
+        public void Put(string value, int maxLength = 0)
         {
-            if (string.IsNullOrEmpty(value))
+            // If a string is null on the server, it should also be null on the client, not "", and vice versa
+            if (value == null)
             {
-                Put(0);
+                Put((ushort)0); // Size (ushort)
                 return;
             }
 
-            //put bytes count
-            int bytesCount = Encoding.UTF8.GetByteCount(value);
-            if (_autoResize)
-                ResizeIfNeed(_position + bytesCount + 4);
-            Put(bytesCount);
+            int length = maxLength > 0 && value.Length > maxLength ? maxLength : value.Length;
+            int size = _uTF8Encoding.GetBytes(value, 0, length, _stringBuffer, 0);
 
-            //put string
-            Encoding.UTF8.GetBytes(value, 0, value.Length, _data, _position);
-            _position += bytesCount;
-        }
-
-        public void Put(string value, int maxLength)
-        {
-            if (string.IsNullOrEmpty(value))
+            if (size >= StringBufferMaxLength)
             {
-                Put(0);
+                Put((ushort)0); // Size (ushort)
                 return;
             }
 
-            int length = value.Length > maxLength ? maxLength : value.Length;
-
-            int totalBytesCount = Encoding.UTF8.GetMaxByteCount(length); //gets max length irrespective of actual length
-
-            if (_autoResize)
-                ResizeIfNeed(_position + totalBytesCount + 4);
-
-            int countPosition = _position; //save position where length needs to be stored
-            _position += 4;
-
-            int requiredBytesCount = Encoding.UTF8.GetBytes(value, 0, length, _data, _position); //put string here
-            int positionAfterWrite = _position + requiredBytesCount; //position where string data ends
-
-            _position = countPosition; //go to position where we need to write int value
-
-            Put(requiredBytesCount); //put length of substring
-            _position = positionAfterWrite; //reset position to final position
+            // "checked" / + 1 for empty ("") strings
+            Put(checked((ushort)(size + 1))); // Size (ushort)
+            Put(_stringBuffer, 0, size); // Buffer
         }
 
         public void Put<T>(T obj) where T : INetSerializable

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -336,10 +336,15 @@ namespace LiteNetLib.Utils
             Put(endPoint.Port);
         }
 
+        public void Put(string value)
+        {
+            Put(value, 0);
+        }
+
         /// <summary>
         /// Note that "maxLength" only limits the number of characters, not the actual string size. It may be different if you use non-ASCII characters, etc.
         /// </summary>
-        public void Put(string value, int maxLength = 0)
+        public void Put(string value, int maxLength)
         {
             // If a string is null on the server, it should also be null on the client, not "", and vice versa
             if (value == null)

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -316,18 +316,18 @@ namespace LiteNetLib.Utils
 
         public void PutArray(string[] value)
         {
-            ushort len = value == null ? (ushort)0 : (ushort)value.Length;
-            Put(len);
-            for (int i = 0; i < len; i++)
+            ushort strArrayLength = value == null ? (ushort)0 : (ushort)value.Length;
+            Put(strArrayLength);
+            for (int i = 0; i < strArrayLength; i++)
                 Put(value[i]);
         }
 
-        public void PutArray(string[] value, int maxLength)
+        public void PutArray(string[] value, int strMaxLength)
         {
-            ushort len = value == null ? (ushort)0 : (ushort)value.Length;
-            Put(len);
-            for (int i = 0; i < len; i++)
-                Put(value[i], maxLength);
+            ushort strArrayLength = value == null ? (ushort)0 : (ushort)value.Length;
+            Put(strArrayLength);
+            for (int i = 0; i < strArrayLength; i++)
+                Put(value[i], strMaxLength);
         }
 
         public void Put(IPEndPoint endPoint)
@@ -342,14 +342,13 @@ namespace LiteNetLib.Utils
         }
 
         /// <summary>
-        /// Note that "maxLength" only limits the number of characters, not the actual string size. It may be different if you use non-ASCII characters, etc.
+        /// Note that "maxLength" only limits the number of characters in a string, not its size in bytes.
         /// </summary>
         public void Put(string value, int maxLength)
         {
-            // If a string is null on the server, it should also be null on the client, not "", and vice versa
             if (value == null)
             {
-                Put((ushort)0); // Size (ushort)
+                Put((ushort)0);
                 return;
             }
 
@@ -358,13 +357,12 @@ namespace LiteNetLib.Utils
 
             if (size >= StringBufferMaxLength)
             {
-                Put((ushort)0); // Size (ushort)
+                Put((ushort)0);
                 return;
             }
 
-            // "checked" / + 1 for empty ("") strings
-            Put(checked((ushort)(size + 1))); // Size (ushort)
-            Put(_stringBuffer, 0, size); // Buffer
+            Put(checked((ushort)(size + 1)));
+            Put(_stringBuffer, 0, size);
         }
 
         public void Put<T>(T obj) where T : INetSerializable


### PR DESCRIPTION
* Read/write string performance boost ~30ms->~18ms (1MB GC -> .8MB GC)
* Solved https://github.com/RevenantX/LiteNetLib/pull/467
* Fixed null string is no longer sent as empty ("")

![1](https://user-images.githubusercontent.com/96641123/148106369-760f9a2e-f05d-4f6f-a5d7-3298ec1536f3.png)
![2](https://user-images.githubusercontent.com/96641123/148106388-69d5fc18-21c8-4577-8cc0-381af6b2e1fc.png)

