### PR TITLE
Android NRE fix & blittable

### DIFF
--- a/LiteNetLib/Utils/FastBitConverter.cs
+++ b/LiteNetLib/Utils/FastBitConverter.cs
@@ -11,13 +11,30 @@ namespace LiteNetLib.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void GetBytes<T>(byte[] bytes, int startIndex, T value) where T : unmanaged
         {
-            if (bytes.Length < startIndex + sizeof(T))
+            int size = sizeof(T);
+            if (bytes.Length < startIndex + size)
                 ThrowIndexOutOfRangeException();
 #if LITENETLIB_UNSAFELIB || NETCOREAPP3_1 || NET5_0 || NETCOREAPP3_0_OR_GREATER
             Unsafe.As<byte, T>(ref bytes[startIndex]) = value;
 #else
             fixed (byte* ptr = &bytes[startIndex])
+            {
+#if UNITY_ANDROID
+                // On some android systems, assigning *(T*)ptr throws a NRE if
+                // the ptr isn't aligned (i.e. if Position is 1,2,3,5, etc.).
+                // Here we have to use memcpy.
+                //
+                // => we can't get a pointer of a struct in C# without
+                //    marshalling allocations
+                // => instead, we stack allocate an array of type T and use that
+                // => stackalloc avoids GC and is very fast. it only works for
+                //    value types, but all blittable types are anyway.
+                T* valueBuffer = stackalloc T[1] { value };
+                UnsafeUtility.MemCpy(ptr, valueBuffer, size);
+#else
                 *(T*)ptr = value;
+#endif
+            }
 #endif
         }
 #else

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -217,9 +217,7 @@ namespace LiteNetLib.Utils
 
         public char GetChar()
         {
-            char result = BitConverter.ToChar(_data, _position);
-            _position += 2;
-            return result;
+            return (char)GetUShort();
         }
 
         public ushort GetUShort()
@@ -401,7 +399,7 @@ namespace LiteNetLib.Utils
 
         public char PeekChar()
         {
-            return BitConverter.ToChar(_data, _position);
+            return (char)PeekUShort();
         }
 
         public ushort PeekUShort()
@@ -517,13 +515,13 @@ namespace LiteNetLib.Utils
 
         public bool TryGetChar(out char result)
         {
-            if (AvailableBytes >= 2)
+            if (!TryGetUShort(out ushort uShortValue))
             {
-                result = GetChar();
-                return true;
+                result = '\0';
+                return false;
             }
-            result = '\0';
-            return false;
+            result = (char)uShortValue;
+            return true;
         }
 
         public bool TryGetShort(out short result)

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -162,10 +162,7 @@ namespace LiteNetLib.Utils
 
         public void Put(char value)
         {
-            if (_autoResize)
-                ResizeIfNeed(_position + 2);
-            FastBitConverter.GetBytes(_data, _position, value);
-            _position += 2;
+            Put((ushort)value);
         }
 
         public void Put(ushort value)


### PR DESCRIPTION
- On some Android systems, assigning ***(T*)ptr** throws a **NRE** if the **ptr** isn't aligned (i.e. if position is 1, 2, 3, 5, etc.). Solution discovered by AIIO, FakeByte, mischa.
- **char** is a [non-blittable type](https://docs.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types). It is safer to cast it as **ushort**.