### PR TITLE
Fix GetPeerById IndexOutOfRangeException

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -365,7 +365,12 @@ namespace LiteNetLib
         /// <returns>Peer if peer with id exist, otherwise null</returns>
         public NetPeer GetPeerById(int id)
         {
-            return _peersArray[id];
+            if (id >= 0 && id < _peersArray.Length)
+            {
+                return _peersArray[id];
+            }
+            
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
`NetManager.cs` says: 

> \<returns>Peer if peer with id exist, otherwise null\</returns>

However, there is no check to see if the given id is within the array's bounds.

This can result in an `IndexOutOfRangeException` (which will not return a null as described).

_I added a basic check to prevent this exception and ensure a null is returned if the peer does not exist._