### PR TITLE
Add TryGetPeerById helper method

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -374,6 +374,18 @@ namespace LiteNetLib
         }
 
         /// <summary>
+        /// Gets peer by peer id
+        /// </summary>
+        /// <param name="id">id of peer</param>
+        /// <returns>True if peer with id exist, otherwise false</returns>
+        public bool TryGetPeerById(int id, out NetPeer peer)
+        {
+            peer = GetPeerById(id);
+
+            return peer != null;
+        }
+
+        /// <summary>
         /// Returns connected peers count
         /// </summary>
         public int ConnectedPeersCount => Interlocked.CompareExchange(ref _connectedPeersCount,0,0);


### PR DESCRIPTION
Added TryGet helper method for GetPeerById:

GetPeerById example usage (current):
```
NetPeer peer = this.netManager.GetPeerById (peerIdentifier);

if (peer != null)
{
    peer.Send (writer, deliveryMethod);
}
```

**TryGetPeerById example usage (new):**
```
if (this.netManager.TryGetPeerById (peerIdentifier, out NetPeer peer))
{
    peer.Send (writer, deliveryMethod);
}
```