### PR TITLE
Fix exception on switch

### DIFF
--- a/LiteNetLib/NetUtils.cs
+++ b/LiteNetLib/NetUtils.cs
@@ -102,23 +102,24 @@ namespace LiteNetLib
                             targetList.Add(address.ToString());
                     }
                 }
+
+	            //Fallback mode (unity android)
+	            if (targetList.Count == 0)
+	            {
+	                IPAddress[] addresses = Dns.GetHostEntry(Dns.GetHostName()).AddressList;
+	                foreach (IPAddress ip in addresses)
+	                {
+	                    if((ipv4 && ip.AddressFamily == AddressFamily.InterNetwork) ||
+	                       (ipv6 && ip.AddressFamily == AddressFamily.InterNetworkV6))
+	                        targetList.Add(ip.ToString());
+	                }
+	            }
             }
             catch
             {
                 //ignored
             }
-
-            //Fallback mode (unity android)
-            if (targetList.Count == 0)
-            {
-                IPAddress[] addresses = Dns.GetHostEntry(Dns.GetHostName()).AddressList;
-                foreach (IPAddress ip in addresses)
-                {
-                    if((ipv4 && ip.AddressFamily == AddressFamily.InterNetwork) ||
-                       (ipv6 && ip.AddressFamily == AddressFamily.InterNetworkV6))
-                        targetList.Add(ip.ToString());
-                }
-            }
+            
             if (targetList.Count == 0)
             {
                 if(ipv4)


### PR DESCRIPTION
This line thrown exception on unity build for switch platform:
[`IPAddress[] addresses = Dns.GetHostEntry(Dns.GetHostName()).AddressList;`](https://github.com/Kaladrius2trip/LiteNetLib/blob/e66044700fcec4790e7d9ffcc6b1f6229c7f15f7/LiteNetLib/NetUtils.cs#L109)
So we can use fallback logic with localhost in this case, right ?