### PR TITLE
Add NetManager.SendUnconnectedMessage with address + port params

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -1369,7 +1369,9 @@ namespace LiteNetLib
         }
 
         /// <summary>
-        /// Send message without connection
+        /// Send message without connection. WARNING This method allocates a new IPEndPoint object and 
+        /// synchronously makes a DNS request. If you're calling this method every frame it will be 
+        /// much faster to just cache the IPEndPoint.
         /// </summary>
         /// <param name="writer">Data serializer</param>
         /// <param name="address">Packet destination IP or hostname</param>

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -1372,6 +1372,20 @@ namespace LiteNetLib
         /// Send message without connection
         /// </summary>
         /// <param name="writer">Data serializer</param>
+        /// <param name="address">Packet destination IP or hostname</param>
+        /// <param name="port">Packet destination port</param>
+        /// <returns>Operation result</returns>
+        public bool SendUnconnectedMessage(NetDataWriter writer, string address, int port)
+        {
+            IPEndPoint remoteEndPoint = NetUtils.MakeEndPoint(address, port);
+
+            return SendUnconnectedMessage(writer.Data, 0, writer.Length, remoteEndPoint);
+        }
+
+        /// <summary>
+        /// Send message without connection
+        /// </summary>
+        /// <param name="writer">Data serializer</param>
         /// <param name="remoteEndPoint">Packet destination</param>
         /// <returns>Operation result</returns>
         public bool SendUnconnectedMessage(NetDataWriter writer, IPEndPoint remoteEndPoint)


### PR DESCRIPTION
Helper method to avoid inlining NetUtils.MakeEndPoint before each SendUnconnected when you only have string address + int port. Same as existing NetManager.Connect (string address, int port, ...) helper method.