### PR TITLE
Correctly check new MTU when using extra package layer

### DIFF
--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -991,7 +991,7 @@ namespace LiteNetLib
             else if(receivedMtu > _mtu && !_finishMtu) //MtuOk
             {
                 //invalid packet
-                if (receivedMtu != NetConstants.PossibleMtu[_mtuIdx + 1])
+                if (receivedMtu != NetConstants.PossibleMtu[_mtuIdx + 1] - NetManager.ExtraPacketSizeForLayer)
                     return;
 
                 lock (_mtuMutex)


### PR DESCRIPTION
When using package layer that adding extra size like Crc32cLayer, the MTU detection is wrong at checking new size.