### PR TITLE
Update inline variables in NetManager.Socket.cs

### DIFF
--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -41,7 +41,7 @@ namespace LiteNetLib
             {
                 if (!Socket.Start(BindAddrIPv4, BindAddrIPv6, Port, ManualMode))
                 {
-                    NetDebug.WriteError("[S] Cannot restore connection \"{0}\",\"{1}\" port {2}", BindAddrIPv4, BindAddrIPv6, Port);
+                    NetDebug.WriteError($"[S] Cannot restore connection \"{BindAddrIPv4}\",\"{BindAddrIPv6}\" port {Port}");
                     Socket?.CloseSocket(false);
                 }
             }


### PR DESCRIPTION
Resolves build error "No overload for method 'WriteError' takes 4 arguments". Tested on Mac M2, Unity 2022.2.6f1 / IOS build.