### PR TITLE
Replace UnitySocketFix with thread safe.

### DIFF
--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -1,8 +1,4 @@
-#if UNITY_IOS && !UNITY_EDITOR
-using UnityEngine;
-#endif
 using System.Runtime.InteropServices;
-
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -12,42 +8,6 @@ using LiteNetLib.Utils;
 
 namespace LiteNetLib
 {
-#if UNITY_IOS && !UNITY_EDITOR
-    public class UnitySocketFix : MonoBehaviour
-    {
-        internal IPAddress BindAddrIPv4;
-        internal IPAddress BindAddrIPv6;
-        internal int Port;
-        internal bool Paused;
-        internal NetManager Socket;
-        internal bool ManualMode;
-
-        private void Update()
-        {
-            if (Socket == null)
-                Destroy(gameObject);
-        }
-
-        private void OnApplicationPause(bool pause)
-        {
-            if (Socket == null)
-                return;
-            if (pause)
-            {
-                Paused = true;
-                Socket.CloseSocket(true);
-            }
-            else if (Paused)
-            {
-                if (!Socket.Start(BindAddrIPv4, BindAddrIPv6, Port, ManualMode))
-                {
-                    NetDebug.WriteError($"[S] Cannot restore connection \"{BindAddrIPv4}\",\"{BindAddrIPv6}\" port {Port}");
-                    Socket?.CloseSocket(false);
-                }
-            }
-        }
-    }
-#endif
 
     public partial class NetManager
     {
@@ -59,6 +19,7 @@ namespace LiteNetLib
         private Thread _threadv6;
         private IPEndPoint _bufferEndPointv4;
         private IPEndPoint _bufferEndPointv6;
+        private PausedSocketFix _pausedSocketFix;
 
 #if !LITENETLIB_UNSAFE
         [ThreadStatic] private static byte[] _sendToBuffer;
@@ -70,9 +31,6 @@ namespace LiteNetLib
         private const int SioUdpConnreset = -1744830452; //SIO_UDP_CONNRESET = IOC_IN | IOC_VENDOR | 12
         private static readonly IPAddress MulticastAddressV6 = IPAddress.Parse("ff02::1");
         public static readonly bool IPv6Support;
-#if UNITY_IOS && !UNITY_EDITOR
-        private UnitySocketFix _unitySocketFix;
-#endif
 
         /// <summary>
         /// Maximum packets count that will be processed in Manual PollEvents
@@ -111,11 +69,6 @@ namespace LiteNetLib
 
         private bool IsActive()
         {
-#if UNITY_IOS && !UNITY_EDITOR
-            var unitySocketFix = _unitySocketFix; //save for multithread
-            if (unitySocketFix != null && unitySocketFix.Paused)
-                return false;
-#endif
             return IsRunning;
         }
 
@@ -304,23 +257,9 @@ namespace LiteNetLib
 
             LocalPort = ((IPEndPoint) _udpSocketv4.LocalEndPoint).Port;
 
-#if UNITY_IOS && !UNITY_EDITOR
-            if (_unitySocketFix == null)
-            {
-                var unityFixObj = new GameObject("LiteNetLib_UnitySocketFix");
-                GameObject.DontDestroyOnLoad(unityFixObj);
-                _unitySocketFix = unityFixObj.AddComponent<UnitySocketFix>();
-                _unitySocketFix.Socket = this;
-                _unitySocketFix.BindAddrIPv4 = addressIPv4;
-                _unitySocketFix.BindAddrIPv6 = addressIPv6;
-                _unitySocketFix.Port = LocalPort;
-                _unitySocketFix.ManualMode = _manualMode;
-            }
-            else
-            {
-                _unitySocketFix.Paused = false;
-            }
-#endif
+            if (_pausedSocketFix == null)
+                _pausedSocketFix = new PausedSocketFix(this, addressIPv4, addressIPv6, port, manualMode);
+
             if (dualMode)
                 _udpSocketv6 = _udpSocketv4;
 

--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -11,6 +11,22 @@ namespace LiteNetLib
 
     public partial class NetManager
     {
+        public bool SocketActive(bool ipv4)
+        {
+            if (ipv4)
+            {
+                if (_udpSocketv4 != null)
+                    return _udpSocketv4.Connected;
+                return false;
+            }
+            else
+            {
+                if (_udpSocketv6 != null)
+                    return _udpSocketv6.Connected;
+                return false;
+            }
+        }
+
         private const int ReceivePollingTime = 500000; //0.5 second
 
         private Socket _udpSocketv4;

--- a/LiteNetLib/PausedSocketFix.cs
+++ b/LiteNetLib/PausedSocketFix.cs
@@ -1,0 +1,73 @@
+
+using System.Net;
+
+namespace LiteNetLib
+{
+
+    public class PausedSocketFix
+    {
+        public bool ApplicationFocused { get; private set; }
+
+        private NetManager _netManager;
+        private IPAddress _ipv4;
+        private IPAddress _ipv6;
+        private int _port;
+        private bool _manualMode;
+
+   
+        public PausedSocketFix() 
+        {
+            UnityEngine.Application.focusChanged += Application_focusChanged;
+        }
+        public PausedSocketFix(NetManager netManager, IPAddress ipv4, IPAddress ipv6, int port, bool manualMode) : this()
+        {
+            Initialize(netManager, ipv4, ipv6, port, manualMode);
+        }
+
+        ~PausedSocketFix()
+        {
+            UnityEngine.Application.focusChanged -= Application_focusChanged;
+        }
+
+        public void Initialize(NetManager netManager, IPAddress ipv4, IPAddress ipv6, int port, bool manualMode)
+        {
+            _netManager = netManager;
+            _ipv4 = ipv4;
+            _ipv6 = ipv6;
+            _port = port;
+            _manualMode = manualMode;
+        }
+
+
+        private void Application_focusChanged(bool focused)
+        {
+            ApplicationFocused = focused;
+            //If coming back into focus see if a reconnect is needed.
+            if (focused)
+                TryReconnect();
+        }
+
+
+        private void TryReconnect()
+        {
+            if (_netManager == null)
+                return;
+            //Was intentionally disconnected at some point.
+            if (!_netManager.IsRunning)
+                return;
+            //Socket is still running.
+            if (_netManager.SocketActive(false) || _netManager.SocketActive(true))
+                return;
+
+            //Socket isn't running but should be. Try to start again.
+            if (!_netManager.Start(_ipv4, _ipv6, _port, _manualMode))
+            {
+                NetDebug.WriteError($"[S] Cannot restore connection. Ipv4 {_ipv4}, Ipv6 {_ipv6}, Port {_port}, ManualMode {_manualMode}");
+                _netManager.CloseSocket(false);
+            }
+        }
+
+
+    }
+
+}


### PR DESCRIPTION
This change replaces UnitySocketFix with PausedSocketFix, a thread safe and less complicated version.

UnitySocketFix would break when LiteNetLib was run on a thread since it's initialization involved creating a gameObject and adding a component.

PausedSocketFix uses thread safe events and a non-monobehaviour class.
PausedSocketFix also brings enhancements to not drop the connection when the application loses focus, but rather only try to reconnect on focus gain if connection was lost.