### PR TITLE
improve: return empty string when its size is 0

### DIFF
--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -283,7 +283,7 @@ namespace LiteNetLib.Utils
             ushort size = GetUShort();
             if (size == 0)
             {
-                return null;
+                return string.Empty;
             }
 
             int actualSize = size - 1;
@@ -304,7 +304,7 @@ namespace LiteNetLib.Utils
             ushort size = GetUShort();
             if (size == 0)
             {
-                return null;
+                return string.Empty;
             }
 
             int actualSize = size - 1;
@@ -447,7 +447,7 @@ namespace LiteNetLib.Utils
             ushort size = PeekUShort();
             if (size == 0)
             {
-                return null;
+                return string.Empty;
             }
 
             int actualSize = size - 1;
@@ -466,7 +466,7 @@ namespace LiteNetLib.Utils
             ushort size = PeekUShort();
             if (size == 0)
             {
-                return null;
+                return string.Empty;
             }
 
             int actualSize = size - 1;


### PR DESCRIPTION
I think it should return an empty string when its size is 0, so we won't have to check null string when reading it, but still return null when its size reached the max length so we can know error occurring because of too big string size