### PR TITLE
Preserve fields used by serializer (Unity)

### DIFF
--- a/LiteNetLib/NatPunchModule.cs
+++ b/LiteNetLib/NatPunchModule.cs
@@ -58,21 +58,21 @@ namespace LiteNetLib
 
         class NatIntroduceRequestPacket
         {
-            public IPEndPoint Internal { get; set; }
-            public string Token { get; set; }
+            public IPEndPoint Internal { [Preserve] get; [Preserve] set; }
+            public string Token { [Preserve] get; [Preserve] set; }
         }
 
         class NatIntroduceResponsePacket
         {
-            public IPEndPoint Internal { get; set; }
-            public IPEndPoint External { get; set; }
-            public string Token { get; set; }
+            public IPEndPoint Internal { [Preserve] get; [Preserve] set; }
+            public IPEndPoint External { [Preserve] get; [Preserve] set; }
+            public string Token { [Preserve] get; [Preserve] set; }
         }
 
         class NatPunchPacket
         {
-            public string Token { get; set; }
-            public bool IsExternal { get; set; }
+            public string Token { [Preserve] get; [Preserve] set; }
+            public bool IsExternal { [Preserve] get; [Preserve] set; }
         }
 
         private readonly NetManager _socket;

--- a/LiteNetLib/Utils/Preserve.cs
+++ b/LiteNetLib/Utils/Preserve.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LiteNetLib.Utils
+{
+    /// <summary>
+    ///   <para>PreserveAttribute prevents byte code stripping from removing a class, method, field, or property.</para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false)]
+    public class PreserveAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
Makes sure to [preserve](https://docs.unity3d.com/ScriptReference/Scripting.PreserveAttribute.html) fields used by the serializer in Unity.

Weird thing is that even with stripping disabled in mono, Unity was still omitting the `set` on all fields for `NatIntroduceResponsePacket`. Not sure why this one only and not `NatIntroduceRequestPacket` or `NatPunchPacket`.