### PR TITLE
Sort Network Interfaces to prefer Wifi over Cellular (local ip)

### DIFF
--- a/LiteNetLib/NetUtils.cs
+++ b/LiteNetLib/NetUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.NetworkInformation;
@@ -22,6 +23,8 @@ namespace LiteNetLib
     /// </summary>
     public static class NetUtils
     {
+        private static readonly NetworkSorter NetworkSorter = new NetworkSorter();
+
         public static IPEndPoint MakeEndPoint(string hostStr, int port)
         {
             return new IPEndPoint(ResolveAddress(hostStr), port);
@@ -81,7 +84,12 @@ namespace LiteNetLib
             bool ipv6 = (addrType & LocalAddrType.IPv6) == LocalAddrType.IPv6;
             try
             {
-                foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
+                // Sort networks interfaces so it prefer Wifi over Cellular networks
+                // Most cellulars networks seems to be incompatible with NAT Punch
+                var networks = NetworkInterface.GetAllNetworkInterfaces();
+                Array.Sort(networks, NetworkSorter);
+
+                foreach (NetworkInterface ni in networks)
                 {
                     //Skip loopback and disabled network interfaces
                     if (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback ||
@@ -185,6 +193,46 @@ namespace LiteNetLib
 #else
             return new T[count];
 #endif
+        }
+    }
+
+    // Pick the most obvious choice for the local IP
+    // Ethernet > Wifi > Others > Cellular
+    internal class NetworkSorter : IComparer<NetworkInterface>
+    {
+        [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
+        public int Compare(NetworkInterface a, NetworkInterface b)
+        {
+            var isCellularA = a.NetworkInterfaceType == NetworkInterfaceType.Wman ||
+                              a.NetworkInterfaceType == NetworkInterfaceType.Wwanpp ||
+                              a.NetworkInterfaceType == NetworkInterfaceType.Wwanpp2;
+
+            var isCellularB = b.NetworkInterfaceType == NetworkInterfaceType.Wman ||
+                              b.NetworkInterfaceType == NetworkInterfaceType.Wwanpp ||
+                              b.NetworkInterfaceType == NetworkInterfaceType.Wwanpp2;
+
+            var isWifiA     = a.NetworkInterfaceType == NetworkInterfaceType.Wireless80211;
+            var isWifiB     = b.NetworkInterfaceType == NetworkInterfaceType.Wireless80211;
+
+            var isEthernetA = a.NetworkInterfaceType == NetworkInterfaceType.Ethernet ||
+                              a.NetworkInterfaceType == NetworkInterfaceType.Ethernet3Megabit ||
+                              a.NetworkInterfaceType == NetworkInterfaceType.GigabitEthernet ||
+                              a.NetworkInterfaceType == NetworkInterfaceType.FastEthernetFx ||
+                              a.NetworkInterfaceType == NetworkInterfaceType.FastEthernetT;
+
+            var isEthernetB = b.NetworkInterfaceType == NetworkInterfaceType.Ethernet ||
+                              b.NetworkInterfaceType == NetworkInterfaceType.Ethernet3Megabit ||
+                              b.NetworkInterfaceType == NetworkInterfaceType.GigabitEthernet ||
+                              b.NetworkInterfaceType == NetworkInterfaceType.FastEthernetFx ||
+                              b.NetworkInterfaceType == NetworkInterfaceType.FastEthernetT;
+
+            var isOtherA    = !isCellularA && !isWifiA && !isEthernetA;
+            var isOtherB    = !isCellularB && !isWifiB && !isEthernetB;
+
+            var priorityA = isEthernetA ? 3 : isWifiA ? 2 : isOtherA ? 1 : 0;
+            var priorityB = isEthernetB ? 3 : isWifiB ? 2 : isOtherB ? 1 : 0;
+
+            return priorityA > priorityB ? -1 : priorityA < priorityB ? 1 : 0;
         }
     }
 }


### PR DESCRIPTION
Most phones are going to have both Cellular and Wifi at the same time and `GetLocalIp` is going to return the IP of the cellular network first most of the times it seems. Instead this sort the network interfaces to prioritize Wifi over Cellular.

Works for my use-case, not sure this is best approach tho, so feels free to just close this.