### PR TITLE
Surface Shutdown Event

### DIFF
--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -617,6 +617,10 @@ namespace LiteNetLib
                         CreateEvent(NetEvent.EType.Error, remoteEndPoint: remoteEndPoint, errorCode: ex.SocketErrorCode);
                         return -1;
 
+                    case SocketError.Shutdown:
+                        CreateEvent(NetEvent.EType.Error, remoteEndPoint: remoteEndPoint, errorCode: ex.SocketErrorCode);
+                        return -1;
+
                     default:
                         NetDebug.WriteError($"[S] {ex}");
                         return -1;


### PR DESCRIPTION
On iOS (Unity) at least, I noticed that the Sockets can become in a permanent "Shutdown" state when you put the App in background and go back to it. Meaning you have to do a `manager.Stop()` / `manager.Start()` to re-create them if you want to call `manager.Connect()` again (which I do now if I catch this event).