### PR TITLE
Fix race condition in NTP sample

### DIFF
--- a/LibSample/NtpTest.cs
+++ b/LibSample/NtpTest.cs
@@ -26,8 +26,8 @@ namespace LibSample
             };
 
             NetManager nm = new NetManager(listener);
-            nm.Start();
             nm.CreateNtpRequest(ntpService);
+            nm.Start();
 
             while (!ntpComplete)
             {


### PR DESCRIPTION
Got this error (once, hard to repro):
```
[NM] LogicThread error: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.Dictionary`2.Enumerator.MoveNext()
   at LiteNetLib.NetManager.ProcessNtpRequests(Int32 elapsedMilliseconds)
   at LiteNetLib.NetManager.UpdateLogic()
```

I might be wrong but I can't find any other possibilities than some race condition where `CreateNtpRequest` get executed at the same time as `ProcessNtpRequests`.

Using a `ConcurrentDictionary` would do the trick as well but making sure `Start()` is called afterward ensure this race condition cannot happens.