### PR TITLE
`AllowPeerAddressChange` requires to implement `IPeerAddressChangedListener`

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -612,7 +612,7 @@ namespace LiteNetLib
                         _peersLock.ExitWriteLock();
                     }
                     _peersLock.ExitUpgradeableReadLock();
-                    if(previousAddress != null)
+                    if(previousAddress != null && _peerAddressChangedListener != null)
                         _peerAddressChangedListener.OnPeerAddressChanged(evt.Peer, previousAddress);
                     break;
             }

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -1049,10 +1049,7 @@ namespace LiteNetLib
                                     if (peer.ConnectionState == ConnectionState.Connected)
                                     {
                                         peer.InitiateEndPointChange();
-                                        if (_peerAddressChangedListener != null)
-                                        {
-                                            CreateEvent(NetEvent.EType.PeerAddressChanged, peer, remoteEndPoint);
-                                        }
+                                        CreateEvent(NetEvent.EType.PeerAddressChanged, peer, remoteEndPoint);
                                         NetDebug.Write("[NM] PeerNotFound change address of remote peer");
                                     }
                                     isOldPeer = true;


### PR DESCRIPTION
Not intuitive that to enable `AllowPeerAddressChange` you also need to implements `IPeerAddressChangedListener`.

There is some necessary code that are parsed in `ProcessEvent()` which don't get called otherwise since the event is never created.

The alternative would be to be clear in the comments description for `AllowPeerAddressChange`, but I feel like this is an unnecessary requirement.