### PR TITLE
Added reflection fallback for Unity preprocessors

### DIFF
--- a/LibSample/LibSample.csproj
+++ b/LibSample/LibSample.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;net471;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks>net6.0;net5.0;net8.0;net471;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net8.0;net6.0;net471</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net471</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\LiteNetLib\LiteNetLib.csproj" />
+    <ProjectReference Include="..\LiteNetLib\LiteNetLib.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/LiteNetLib.Tests/AppEnvironmentTest.cs
+++ b/LiteNetLib.Tests/AppEnvironmentTest.cs
@@ -1,0 +1,43 @@
+﻿using LiteNetLib.Tests.TestUtility;
+using NUnit.Framework;
+
+namespace LiteNetLib.Tests;
+
+[TestFixture]
+public class AppEnvironmentTest
+{
+    [Test]
+    public void UnityIsAvailable()
+    {
+        var unityCode = """
+                        namespace UnityEngine;
+
+                        public static class Application
+                        {
+                        }
+                        """;
+        string programCode = """
+                             using System;
+                             using System.Linq;
+                             using System.Reflection;
+
+                             public static class Program
+                             {
+                                 public static bool UnityIsAvailable()
+                                 {
+                                    return (bool)Type.GetType("LiteNetLib.AppEnvironment, LiteNetLib").GetNestedType("Unity", BindingFlags.NonPublic).GetProperty("IsAvailable").GetMethod.Invoke(null, null);
+                                 }
+                             }
+                             """;
+
+        using (var dynamicCode = new CodeContext())
+        {
+            dynamicCode.AddAssemblyFromCode("UnityIsAvailable", programCode);
+            var isolatedExecute = dynamicCode.GetType("Program, UnityIsAvailable")?.GetMethod("UnityIsAvailable");
+            Assert.NotNull(isolatedExecute);
+            Assert.IsFalse((bool)isolatedExecute.Invoke(null, null));
+            dynamicCode.AddAssemblyFromCode("UnityEngine.CoreModule", unityCode);
+            Assert.IsTrue((bool)isolatedExecute.Invoke(null, null));
+        }
+    }
+}

--- a/LiteNetLib.Tests/LiteNetLib.Tests.csproj
+++ b/LiteNetLib.Tests/LiteNetLib.Tests.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net5.0;net471;netcoreapp3.1</TargetFrameworks>
-    <ApplicationIcon />
-    <StartupObject />
-    <TargetFrameworks>net6.0;net5.0;net471;netcoreapp3.1;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net8.0;net471</TargetFrameworks>
+    <ApplicationIcon/>
+    <StartupObject/>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+    <PackageReference Include="NUnit" Version="3.14.0"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -19,11 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\LiteNetLib\LiteNetLib.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="TestUtility\" />
+    <ProjectReference Include="..\LiteNetLib\LiteNetLib.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/LiteNetLib.Tests/NetDebugTest.cs
+++ b/LiteNetLib.Tests/NetDebugTest.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using LiteNetLib.Tests.TestUtility;
+using NUnit.Framework;
+
+namespace LiteNetLib.Tests;
+
+[TestFixture]
+public class NetDebugTest
+{
+    [Test]
+    public void UsesConsoleOutputByDefault()
+    {
+        var input = "hello from console output";
+        using (new ConsoleOutputCapturer(out TextWriter consoleOut))
+        {
+            NetDebug.WriteError(input);
+            Assert.AreEqual(input + Environment.NewLine, consoleOut.ToString());
+        }
+    }
+
+    [Test]
+    public void UsesUnityLogFormatIfAvailable()
+    {
+        // Implements fake Unity log API: https://docs.unity3d.com/ScriptReference/Debug.LogFormat.html
+        var code = """
+                   namespace UnityEngine;
+                   
+                   public static class Debug
+                   {
+                       public static void LogFormat(string format, object[] args)
+                       {
+                           // Fake implementation to test that this is called
+                           System.Console.WriteLine("[Unity] " + format);
+                       }
+                   }
+                   """;
+        using (var tempAssembly = CodeContext.CreateAndLoad("UnityEngine.CoreModule", code))
+        {
+            Action<string, object[]> unityLogFormat = (Action<string, object[]>)tempAssembly
+                .GetType("UnityEngine.Debug, UnityEngine.CoreModule")
+                ?.GetMethod("LogFormat", new[] { typeof(string), typeof(object[]) })
+                ?.CreateDelegate(typeof(Action<string, object[]>));
+            Assert.NotNull(unityLogFormat);
+            using (new ConsoleOutputCapturer(out TextWriter tempOut))
+            {
+                unityLogFormat("test", Array.Empty<object>());
+                Assert.AreEqual("[Unity] test" + Environment.NewLine, tempOut.ToString());
+            }
+        }
+    }
+}

--- a/LiteNetLib.Tests/TestUtility/CodeContext.cs
+++ b/LiteNetLib.Tests/TestUtility/CodeContext.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace LiteNetLib.Tests.TestUtility;
+
+internal class CodeContext : IDisposable
+{
+    private static readonly string[] DefaultNamespaces =
+    {
+        "System",
+        "System.IO",
+        "System.Net",
+        "System.Linq",
+        "System.Text",
+        "System.Text.RegularExpressions",
+        "System.Collections.Generic"
+    };
+
+    private readonly AssemblyLoadContext _assemblyContext;
+
+    private readonly Lazy<MetadataReference[]> _managedRuntimeReferences = new(() =>
+    {
+        var netRuntimePath = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (!Directory.Exists(netRuntimePath))
+            throw new DirectoryNotFoundException($".NET Runtime path '{netRuntimePath}' is not found");
+
+        List<MetadataReference> references = new();
+        foreach (var file in Directory.GetFiles(netRuntimePath, "System.*"))
+        {
+            if (file.Contains(".Native.", StringComparison.Ordinal)) continue;
+
+            references.Add(MetadataReference.CreateFromFile(file));
+        }
+
+        return references.ToArray();
+    });
+
+    public CodeContext()
+    {
+        _assemblyContext = new AssemblyLoadContext("Temporary " + Guid.NewGuid(), true);
+    }
+
+    public void Dispose()
+    {
+        _assemblyContext.Unload();
+    }
+
+    public void AddAssemblyFromCode(string assemblyName, string code, params Assembly[] references)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(code) },
+            _managedRuntimeReferences.Value.Concat(
+                references?.Select(r => MetadataReference.CreateFromFile(r.Location)) ??
+                ArraySegment<PortableExecutableReference>.Empty),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithUsings(DefaultNamespaces)
+                .WithOverflowChecks(true));
+        // Compile code in memory to an assembly image
+        using MemoryStream assemblyMemory = new();
+        var emitResult = compilation.Emit(assemblyMemory);
+        IEnumerable<Diagnostic> failures = emitResult.Diagnostics.Where(diagnostic =>
+            diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        if (failures.Any())
+            throw new Exception($"Compilation errors{Environment.NewLine}{string.Join(Environment.NewLine, failures)}");
+
+        // Load assembly image into .NET assembly context with unloading support
+        assemblyMemory.Position = 0;
+        _assemblyContext.LoadFromStream(assemblyMemory);
+    }
+
+    public static CodeContext CreateAndLoad(string assemblyName, string code, params Assembly[] references)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(assemblyName);
+        ArgumentException.ThrowIfNullOrEmpty(code);
+
+        var context = new CodeContext();
+        context.AddAssemblyFromCode(assemblyName, code, references);
+        return context;
+    }
+
+    public Type GetType(string typeName)
+    {
+        var typeParts = typeName.Split(',', StringSplitOptions.TrimEntries);
+        var applicableAssemblies = _assemblyContext.Assemblies;
+        if (typeParts.Length >= 2)
+            applicableAssemblies = applicableAssemblies.Where(a => a.GetName().Name == typeParts[1]);
+        foreach (var assembly in applicableAssemblies)
+        {
+            var type = assembly.GetType(typeParts[0]);
+            if (type != null) return type;
+        }
+
+        return null;
+    }
+}

--- a/LiteNetLib.Tests/TestUtility/ConsoleOutputCapturer.cs
+++ b/LiteNetLib.Tests/TestUtility/ConsoleOutputCapturer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.IO;
+
+namespace LiteNetLib.Tests.TestUtility;
+
+internal readonly struct ConsoleOutputCapturer : IDisposable
+{
+    private readonly TextWriter _previousStream;
+    private readonly TextWriter _innerWriter;
+
+    public ConsoleOutputCapturer(TextWriter newStream)
+    {
+        _previousStream = Console.Out;
+        Console.SetOut(newStream);
+    }
+
+    public ConsoleOutputCapturer(out TextWriter tempOut)
+    {
+        _previousStream = Console.Out;
+        _innerWriter = tempOut = new StringWriter();
+        Console.SetOut(tempOut);
+    }
+
+    public void Dispose()
+    {
+        Console.SetOut(_previousStream);
+        _innerWriter?.Dispose();
+    }
+}

--- a/LiteNetLib/AppEnvironment.cs
+++ b/LiteNetLib/AppEnvironment.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace LiteNetLib
+{
+    internal static class AppEnvironment
+    {
+        internal static class Unity
+        {
+            [ThreadStatic] private static Version _version;
+            private static readonly Version _fallbackVersion = new Version(1, 0);
+            [ThreadStatic] private static bool? _isEditor;
+            [ThreadStatic] private static bool? _isIl2cpp;
+            [ThreadStatic] private static bool? _isAndroidPlatform;
+            [ThreadStatic] private static bool? _isSwitchPlatform;
+            private static object _unityApplicationTypeLock = new object();
+            private static Type _unityApplicationType;
+
+            private static Type UnityApplicationType
+            {
+                get
+                {
+                    lock (_unityApplicationTypeLock)
+                    {
+
+                        if (_unityApplicationType != null)
+                        {
+                            return _unityApplicationType;
+                        }
+
+#if UNITY_2018_3_OR_NEWER
+                        return _unityApplicationType = typeof(UnityEngine.Application);
+#else
+                        return _unityApplicationType = AppDomain.CurrentDomain.GetAssemblies()
+                            .FirstOrDefault(a => a.GetName().Name == "UnityEngine.CoreModule")
+                            ?.GetType("UnityEngine.Application");
+#endif
+                    }
+                }
+            }
+
+            public static bool IsAvailable => UnityApplicationType != null;
+
+            /// <summary>
+            ///     Gets the version of the currently executing Unity engine.
+            /// </summary>
+            public static Version Version
+            {
+                get
+                {
+                    if (_version != null)
+                    {
+                        return _version;
+                    }
+                    if (!IsAvailable)
+                    {
+                        return _version = _fallbackVersion;
+                    }
+
+                    string version;
+#if UNITY_2018_3_OR_NEWER
+                    version = UnityEngine.Application.unityVersion;
+#else
+                    version = UnityApplicationType?.GetProperty("unityVersion")?.GetValue(null) as string;
+#endif
+                    if (version == null)
+                        return _version = _fallbackVersion;
+                    // See https://regex101.com/r/gZQvfX/1 to test regex
+                    version = new Regex(@"\d+(?:\.\d*){1,3}").Match(version).Value;
+                    if (!Version.TryParse(version, out Version result))
+                        return null;
+                    return _version = result;
+                }
+            }
+
+            public static bool IsAndroidPlatform
+            {
+                get
+                {
+#if UNITY_2018_3_OR_NEWER
+                    return UnityEngine.Application.platform == RuntimePlatform.Android;
+#else
+                    if (!_isAndroidPlatform.HasValue)
+                    {
+                        _isAndroidPlatform = UnityApplicationType
+                                                 ?.GetProperty("platform", BindingFlags.Public | BindingFlags.Static)
+                                                 ?.GetValue(null)
+                                                 ?.ToString()
+                                                 ?.Equals("android", StringComparison.OrdinalIgnoreCase) ??
+                                             false;
+                    }
+                    return _isAndroidPlatform.Value;
+#endif
+                }
+            }
+
+            public static bool IsSwitchPlatform
+            {
+                get
+                {
+#if UNITY_2018_3_OR_NEWER
+                    return UnityEngine.Application.platform == RuntimePlatform.Switch;
+#else
+                    if (!_isSwitchPlatform.HasValue)
+                    {
+                        _isSwitchPlatform = UnityApplicationType
+                                                ?.GetProperty("platform", BindingFlags.Public | BindingFlags.Static)
+                                                ?.GetValue(null)
+                                                ?.ToString()
+                                                .Equals("switch", StringComparison.OrdinalIgnoreCase) ??
+                                            false;
+                    }
+                    return _isSwitchPlatform.Value;
+#endif
+                }
+            }
+
+            public static bool IsEditor
+            {
+                get
+                {
+#if UNITY_2018_3_OR_NEWER
+                    return UnityEngine.Application.isEditor;
+#else
+                    if (!_isEditor.HasValue)
+                    {
+                        _isEditor = UnityApplicationType
+                            ?.GetProperty("isEditor", BindingFlags.Public | BindingFlags.Static)
+                            ?.GetValue(null) is true;
+                    }
+                    return _isEditor.Value;
+#endif
+                }
+            }
+
+            public static bool IsIl2cpp
+            {
+                get
+                {
+#if ENABLE_IL2CPP
+                    return true;
+#else
+                    if (!_isIl2cpp.HasValue)
+                    {
+                        _isIl2cpp = Type.GetType("System.__Il2CppComObject") != null;
+                    }
+                    return _isIl2cpp.Value;
+#endif
+                }
+            }
+        }
+    }
+}

--- a/LiteNetLib/LiteNetLib.csproj
+++ b/LiteNetLib/LiteNetLib.csproj
@@ -62,4 +62,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="LiteNetLib.Tests"/>
+  </ItemGroup>
+
 </Project>

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -1663,10 +1663,11 @@ namespace LiteNetLib
                 return;
             NetDebug.Write("[NM] Stop");
 
-#if UNITY_2018_3_OR_NEWER
-            _pausedSocketFix.Deinitialize();
-            _pausedSocketFix = null;
-#endif
+            if (_pausedSocketFix != null)
+            {
+                _pausedSocketFix.Deinitialize();
+                _pausedSocketFix = null;
+            }
 
             //Send last disconnect
             for(var netPeer = _headPeer; netPeer != null; netPeer = netPeer.NextPeer)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Lite reliable UDP library for .NET Standard 2.0 (Mono, .NET Core, .NET Framework
 
 ## Unity notes!!!
 * Minimal supported Unity is 2018.3. For older Unity versions use [0.9.x library](https://github.com/RevenantX/LiteNetLib/tree/0.9) versions
-* Always use library sources instead of precompiled DLL files ( because there are platform specific #ifdefs and workarounds for unity bugs )
+* If using IL2CPP, always use library sources instead of precompiled DLL files ( because there are platform specific #ifdefs for Unity bugs )
 
 ## Usage samples
 


### PR DESCRIPTION
 - This allows LNL to be used via NuGet and still apply Unity specific fixes (useful for Unity game mods that want to use LNL)
 - IL2CPP still requires LNL to be compiled with the project code since IL2CPP can aggressively omit types, and their methods, breaking this fallback logic.