### PR TITLE
Use local IPv6 address when masterServerEndPoint is an IPv6 address

### DIFF
--- a/LiteNetLib/NatPunchModule.cs
+++ b/LiteNetLib/NatPunchModule.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Net;
+using System.Net.Sockets;
 using LiteNetLib.Utils;
 
 namespace LiteNetLib
@@ -173,7 +174,7 @@ namespace LiteNetLib
         {
             //prepare outgoing data
             string networkIp = NetUtils.GetLocalIp(LocalAddrType.IPv4);
-            if (string.IsNullOrEmpty(networkIp))
+            if (string.IsNullOrEmpty(networkIp) || masterServerEndPoint.AddressFamily == AddressFamily.InterNetworkV6)
             {
                 networkIp = NetUtils.GetLocalIp(LocalAddrType.IPv6);
             }


### PR DESCRIPTION
This change is to allow the use of an IPv6 LNL punch through server with LiteNetLib. If a masterServerEndPoint IP is IPv6, the local IPv6 address should be used for the SendNatIntroduceRequest packet, otherwise the protocols will be mismatched.