### PR TITLE
Fix Linux Specific Softlock on empty datagrams

### DIFF
--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -187,21 +187,24 @@ namespace LiteNetLib
                     continue;
                 }
                 bool messageReceived = false;
-                if (socketv4.Available != 0)
+                if (socketv4.Available != 0 || selectReadList.Contains(socketv4))
                 {
                     if (NativeReceiveFrom(ref packet, socketHandle4, addrBuffer4, addrSize4) == false)
                         return;
                     messageReceived = true;
                 }
-                if (socketV6.Available != 0)
+                if (socketV6.Available != 0 || selectReadList.Contains(socketV6))
                 {
                     if (NativeReceiveFrom(ref packet, socketHandle6, addrBuffer6, addrSize6) == false)
                         return;
                     messageReceived = true;
                 }
+
+                selectReadList.Clear();
+
                 if (messageReceived)
                     continue;
-                selectReadList.Clear();
+                
                 selectReadList.Add(socketv4);
                 selectReadList.Add(socketV6);
                 try
@@ -270,10 +273,12 @@ namespace LiteNetLib
                             ReceiveFrom(socketV6, ref bufferEndPoint6);
                             messageReceived = true;
                         }
+
+                        selectReadList.Clear();
+
                         if (messageReceived)
                             continue;
 
-                        selectReadList.Clear();
                         selectReadList.Add(socketv4);
                         selectReadList.Add(socketV6);
                         Socket.Select(selectReadList, null, null, ReceivePollingTime);

--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -146,7 +146,8 @@ namespace LiteNetLib
             //Reading data
             packet.Size = NativeSocket.RecvFrom(s, packet.RawData, NetConstants.MaxPacketSize, addrBuffer, ref addrSize);
             if (packet.Size == 0)
-                return false; //socket closed
+                return true; //socket closed or empty packet
+
             if (packet.Size == -1)
             {
                 var errorCode = NativeSocket.GetSocketError();
@@ -204,7 +205,7 @@ namespace LiteNetLib
 
                 if (messageReceived)
                     continue;
-                
+
                 selectReadList.Add(socketv4);
                 selectReadList.Add(socketV6);
                 try

--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -263,12 +263,12 @@ namespace LiteNetLib
                     else
                     {
                         bool messageReceived = false;
-                        if (socketv4.Available != 0)
+                        if (socketv4.Available != 0 || selectReadList.Contains(socketv4))
                         {
                             ReceiveFrom(socketv4, ref bufferEndPoint4);
                             messageReceived = true;
                         }
-                        if (socketV6.Available != 0)
+                        if (socketV6.Available != 0 || selectReadList.Contains(socketV6))
                         {
                             ReceiveFrom(socketV6, ref bufferEndPoint6);
                             messageReceived = true;


### PR DESCRIPTION
Due to a difference in behaviour in DotNet on linux the Socket::Available property behaves differently.

On linux it will return 0 when an empty datagram is received, which results in the receivethread softlocking.
To resolve this we can use the selectReadList alongside Socket::Available.

Additionally, on linux the native socket will return a size 0 for empty packets aswel.
So we shouldn't kill the receive loop when the size is 0, as that would mean an empty packet can kill the receive thread.