### PR TITLE
Nested `INetSerializable` arrays serialization

### DIFF
--- a/LiteNetLib.Tests/NetSerializerTest.cs
+++ b/LiteNetLib.Tests/NetSerializerTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using LiteNetLib.Utils;
 
@@ -16,17 +18,19 @@ namespace LiteNetLib.Tests
             _samplePacket = new SamplePacket
             {
                 SomeFloat = 3.42f,
-                SomeIntArray = new[] {6, 5, 4},
+                SomeIntArray = new[] { 6, 5, 4 },
                 SomeString = "Test String",
                 SomeVector2 = new SomeVector2(4, 5),
-                SomeVectors = new[] {new SomeVector2(1, 2), new SomeVector2(3, 4)},
+                SomeVectors = new[] { new SomeVector2(1, 2), new SomeVector2(3, 4) },
                 SomeEnum = TestEnum.B,
                 SomeByteArray = new byte[] { 255, 1, 0 },
-                TestObj = new SampleNetSerializable {Value = 5},
-                TestArray = new [] { new SampleNetSerializable { Value = 6 }, new SampleNetSerializable { Value = 15 } },
-                SampleClassArray = new[] { new SampleClass { Value = 6 }, new SampleClass { Value = 15 } },
-                SampleClassList = new List<SampleClass> { new SampleClass { Value = 1 }, new SampleClass { Value = 5 }},
-                VectorList = new List<SomeVector2> { new SomeVector2(-1,-2), new SomeVector2(700, 800) },
+                TestObj = new SampleNetSerializable { Value = 5 },
+                TestArray = new[] { new SampleNetSerializable { Value = 6 }, new SampleNetSerializable { Value = 15 } },
+                SampleClassArray = new[]
+                    { FillTestArray(new SampleClass { Value = 6 }), FillTestArray(new SampleClass { Value = 15 }) },
+                SampleClassList = new List<SampleClass>
+                    { FillTestArray(new SampleClass { Value = 1 }), FillTestArray(new SampleClass { Value = 5 }) },
+                VectorList = new List<SomeVector2> { new SomeVector2(-1, -2), new SomeVector2(700, 800) },
                 IgnoreMe = 1337
             };
 
@@ -83,7 +87,37 @@ namespace LiteNetLib.Tests
         private class SampleClass : INetSerializable
         {
             public int Value;
+            public ChildClass[] TestArray = Array.Empty<ChildClass>();
 
+            public void Serialize(NetDataWriter writer)
+            {
+                writer.Put(Value);
+                writer.PutArray(TestArray);
+            }
+
+            public void Deserialize(NetDataReader reader)
+            {
+                Value = reader.GetInt();
+                TestArray = reader.GetArray<ChildClass>();
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = (SampleClass)obj;
+                return other.Value == Value && (TestArray is null && other.TestArray is null || TestArray != null &&
+                    other.TestArray != null && TestArray.SequenceEqual(other.TestArray));
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
+        }
+
+        private class ChildClass : INetSerializable
+        {
+            public int Value;
+            
             public void Serialize(NetDataWriter writer)
             {
                 writer.Put(Value);
@@ -93,15 +127,10 @@ namespace LiteNetLib.Tests
             {
                 Value = reader.GetInt();
             }
-
+            
             public override bool Equals(object obj)
             {
-                return ((SampleClass)obj).Value == Value;
-            }
-
-            public override int GetHashCode()
-            {
-                return base.GetHashCode();
+                return ((ChildClass)obj).Value == Value;
             }
         }
 
@@ -138,6 +167,15 @@ namespace LiteNetLib.Tests
                 return true;
             }
             return s1 == s2;
+        }
+
+        private static SampleClass FillTestArray(SampleClass obj)
+        {
+            var random = new Random();
+            obj.TestArray = new ChildClass[random.Next(10)];
+            for (int i = 0; i < obj.TestArray.Length; i++)
+                obj.TestArray[i] = new ChildClass { Value = random.Next() };
+            return obj;
         }
 
         [Test, MaxTime(2000)]

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -225,6 +225,20 @@ namespace LiteNetLib.Utils
             return result;
         }
 
+        public T[] GetArray<T>() where T : INetSerializable, new()
+        {
+            ushort length = BitConverter.ToUInt16(_data, _position);
+            _position += 2;
+            T[] result = new T[length];
+            for (int i = 0; i < length; i++)
+            {
+                var item = new T();
+                item.Deserialize(this);
+                result[i] = item;
+            }
+            return result;
+        }
+        
         public bool[] GetBoolArray()
         {
             return GetArray<bool>(1);

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -337,6 +337,14 @@ namespace LiteNetLib.Utils
             for (int i = 0; i < strArrayLength; i++)
                 Put(value[i], strMaxLength);
         }
+        
+        public void PutArray<T>(T[] value) where T : INetSerializable, new()
+        {
+            ushort strArrayLength = (ushort)(value?.Length ?? 0);
+            Put(strArrayLength);
+            for (int i = 0; i < strArrayLength; i++)
+                value[i].Serialize(this);
+        }
 
         public void Put(IPEndPoint endPoint)
         {


### PR DESCRIPTION
This PR adds methods to serialize and deserialize arrays of classes or structs that implements the `INetSerializable` interface and nested inside other `INetSerializable`.