### PR TITLE
improve PausedSocketFix, Fix peerIdsQueue

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -355,7 +355,9 @@ namespace LiteNetLib
 
         public NetManager(bool useSocketFix = true)
         {
+#if UNITY_SOCKET_FIX
             _useSocketFix = useSocketFix;
+#endif
         }
         /// <summary>
         /// NetManager constructor

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -748,7 +748,7 @@ namespace LiteNetLib
                 const int maxIdValue = int.MaxValue;
                 long addable = Math.Min(addCount, (maxIdValue - _nextPeerId));
 
-                if (addable == 0)
+                if (addable <= 0)
                 {
                     NetDebug.Write(NetLogLevel.Error, $"[NM] PeerIds have exceeded the maximum value of {maxIdValue}. A new Id cannot be returned.");
                     return 0;


### PR DESCRIPTION
- Added PausedSocketFix usage is now optional via NetManager ctor. Default set to use.
- Fixed peer Ids not returning to _peerIdsQueue.
- Improved queue usage to be more flexible with other applications.
- Improved added error checking for when no more peerIds are available.
- Changed _lastPeerId to _nextPeerId for clarity.
- Changed UNITY_2018__3_OR_NEWER define related to PausedSocketFix to UNITY_SOCKET_FIX for clarity.