### PR TITLE
Serialization enhancements

### DIFF
--- a/LiteNetLib.Tests/NetSerializerTest.cs
+++ b/LiteNetLib.Tests/NetSerializerTest.cs
@@ -20,6 +20,7 @@ namespace LiteNetLib.Tests
                 SomeFloat = 3.42f,
                 SomeIntArray = new[] { 6, 5, 4 },
                 SomeString = "Test String",
+                SomeGuid = Guid.NewGuid(),
                 SomeVector2 = new SomeVector2(4, 5),
                 SomeVectors = new[] { new SomeVector2(1, 2), new SomeVector2(3, 4) },
                 SomeEnum = TestEnum.B,
@@ -148,6 +149,7 @@ namespace LiteNetLib.Tests
             public int[] SomeIntArray { get; set; }
             public byte[] SomeByteArray { get; set; }
             public string SomeString { get; set; }
+            public Guid SomeGuid { get; set; }
             public SomeVector2 SomeVector2 { get; set; }
             public SomeVector2[] SomeVectors { get; set; }
             public TestEnum SomeEnum { get; set; }
@@ -200,6 +202,7 @@ namespace LiteNetLib.Tests
             Assert.AreEqual(_samplePacket.SomeFloat, readPackage.SomeFloat);
             Assert.AreEqual(_samplePacket.SomeIntArray, readPackage.SomeIntArray);
             Assert.IsTrue(AreSame(_samplePacket.SomeString, readPackage.SomeString));
+            Assert.AreEqual(_samplePacket.SomeGuid, readPackage.SomeGuid);
             Assert.AreEqual(_samplePacket.SomeVector2, readPackage.SomeVector2);
             Assert.AreEqual(_samplePacket.SomeVectors, readPackage.SomeVectors);
             Assert.AreEqual(_samplePacket.SomeEnum, readPackage.SomeEnum);

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -239,6 +239,16 @@ namespace LiteNetLib.Utils
             return result;
         }
         
+        public T[] GetArray<T>(Func<T> constructor) where T : class, INetSerializable
+        {
+            ushort length = BitConverter.ToUInt16(_data, _position);
+            _position += 2;
+            T[] result = new T[length];
+            for (int i = 0; i < length; i++)
+                Get(out result[i], constructor);
+            return result;
+        }
+        
         public bool[] GetBoolArray()
         {
             return GetArray<bool>(1);

--- a/LiteNetLib/Utils/NetDataReader.cs
+++ b/LiteNetLib/Utils/NetDataReader.cs
@@ -194,6 +194,11 @@ namespace LiteNetLib.Utils
         {
             result = GetString(maxLength);
         }
+        
+        public void Get(out Guid result)
+        {
+            result = GetGuid();
+        }
 
         public IPEndPoint GetNetEndPoint()
         {
@@ -428,6 +433,17 @@ namespace LiteNetLib.Utils
             ArraySegment<byte> data = GetBytesSegment(actualSize);
 
             return NetDataWriter.uTF8Encoding.Value.GetString(data.Array, data.Offset, data.Count);
+        }
+        
+        public Guid GetGuid()
+        {
+#if LITENETLIB_SPANS || NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NETSTANDARD2_1
+            var result =  new Guid(_data.AsSpan(_position, 16));
+            _position += 16;
+            return result;
+#else
+            return new Guid(GetBytesWithLength());
+#endif
         }
 
         public ArraySegment<byte> GetBytesSegment(int count)

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -216,6 +216,18 @@ namespace LiteNetLib.Utils
             _position++;
         }
 
+        public void Put(Guid value)
+        {
+#if LITENETLIB_SPANS || NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NETSTANDARD2_1
+            if (_autoResize)
+                ResizeIfNeed(_position + 16);
+            value.TryWriteBytes(_data.AsSpan(_position));
+            _position += 16;
+#else
+            PutBytesWithLength(value.ToByteArray());
+#endif
+        }
+
         public void Put(byte[] data, int offset, int length)
         {
             if (_autoResize)

--- a/LiteNetLib/Utils/NetSerializer.cs
+++ b/LiteNetLib/Utils/NetSerializer.cs
@@ -422,6 +422,12 @@ namespace LiteNetLib.Utils
             protected override void ElementWrite(NetDataWriter w, ref IPEndPoint prop) { w.Put(prop); }
             protected override void ElementRead(NetDataReader r, out IPEndPoint prop) { prop = r.GetNetEndPoint(); }
         }
+        
+        private class GuidSerializer<T> : FastCallSpecificAuto<T, Guid>
+        {
+            protected override void ElementWrite(NetDataWriter w, ref Guid guid) { w.Put(guid); }
+            protected override void ElementRead(NetDataReader r, out Guid guid) { guid = r.GetGuid(); }
+        }
 
         private class StringSerializer<T> : FastCallSpecific<T, string>
         {
@@ -645,6 +651,8 @@ namespace LiteNetLib.Utils
                     serialzer = new CharSerializer<T>();
                 else if (elementType == typeof(IPEndPoint))
                     serialzer = new IPEndPointSerializer<T>();
+                else if (elementType == typeof(Guid))
+                    serialzer = new GuidSerializer<T>();
                 else
                 {
                     _registeredTypes.TryGetValue(elementType, out var customType);


### PR DESCRIPTION
This PR adds the following two things:
- A method to deserialize an array of `INetSerializable`'s with the  possibility to specify a constructor, mainly to support the deserialization of Unity's `ScriptableObject`.
- The possibility to serialize and deserialize the `Guid` struct.