### PR TITLE
Replace DEBUG pre-processing tags with Conditional attribute

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -153,6 +153,12 @@ namespace LiteNetLib
         private byte _channelsCount = 1;
         private readonly object _eventLock = new object();
 
+        /// <summary>
+        ///     Used with <see cref="SimulateLatency"/> and <see cref="SimulatePacketLoss"/> to tag packets that
+        ///     need to be dropped. Only relevant when <c>DEBUG</c> is defined.
+        /// </summary>
+        private bool dropPacket;
+
         //config section
         /// <summary>
         /// Enable messages receiving without connection. (with SendUnconnectedMessage method)
@@ -793,8 +799,6 @@ namespace LiteNetLib
             // ProcessEvents
             HandleMessageReceived(packet, remoteEndPoint);
         }
-
-        private bool dropPacket;
 
         [Conditional("DEBUG")]
         private void HandleSimulateLatency(NetPacket packet, IPEndPoint remoteEndPoint)


### PR DESCRIPTION
Fixes a bug where simulated packet loss and latency does not work unless end-user cloned repo. This is because those features were locked behind the DEBUG pre-processor tag. This PR replaces the `#if DEBUG` pre-processing tags with methods guarded by the `[Conditional("DEBUG")]` attribute instead.

# Testing

- Case: `Simulate* = true` + `DEBUG` defined.
  - Result: Packet loss and latency is simulated ✔️ 
- Case: `Simulate* = true` + `DEBUG` not defined.
  - Result: Packet loss and latency is not simulated ✔️ 
- Case: `Simulate* = false` + `DEBUG` defined.
  - Result: Packet loss and latency is not simulated ✔️ 
- Case: `Simulate* = false` + `DEBUG` not defined.
  - Result: Packet loss and latency is not simulated ✔️ 