### PR TITLE
Fix crash when sending Merged byte without data

### DIFF
--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -1188,6 +1188,9 @@ namespace LiteNetLib
                     while (pos < packet.Size)
                     {
                         ushort size = BitConverter.ToUInt16(packet.RawData, pos);
+                        if (size == 0)
+                            break;
+                        
                         pos += 2;
                         if (packet.RawData.Length - pos < size)
                             break;


### PR DESCRIPTION
The error occurs in NetPacket::Verify (IndexOutOfRangeException: Index was outside the boundaries of the array)