### PR TITLE
Prevent unnecessary allocations in `NetManager.ProcessNtpRequests`.

### DIFF
--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -638,6 +638,11 @@ namespace LiteNetLib
 
         private void ProcessNtpRequests(float elapsedMilliseconds)
         {
+            if (_ntpRequests.IsEmpty)
+            {
+                return;
+            }
+
             List<IPEndPoint> requestsToRemove = null;
             foreach (var ntpRequest in _ntpRequests)
             {


### PR DESCRIPTION
While profiling I noticed that `ConcurrentQueue`'s enumerator, which is used by `ProcessNtpRequests` is unnecessarily allocating a lot of data. I don't know internal details about that, but simple early return if there's no NTP requests to process seems to fix it.

<img width="589" alt="image" src="https://github.com/user-attachments/assets/f9d676e4-09c5-4e2b-a8c4-732a9b0b2c26" />

<img width="382" alt="image" src="https://github.com/user-attachments/assets/a77dad9a-884d-4837-8b25-c06d90ce20d2" />