### PR TITLE
Support for connecting and writing span of bytes

### DIFF
--- a/LiteNetLib.Tests/ReaderWriterSimpleDataTest.cs
+++ b/LiteNetLib.Tests/ReaderWriterSimpleDataTest.cs
@@ -1,6 +1,7 @@
 ﻿using LiteNetLib.Utils;
 
 using NUnit.Framework;
+using System;
 
 namespace LiteNetLib.Tests
 {
@@ -58,6 +59,26 @@ namespace LiteNetLib.Tests
                 new byte[] {1, 2, 4, 8, 16, byte.MaxValue, byte.MinValue},
                 Is.EqualTo(readByteArray).AsCollection);
         }
+
+#if NET5_0_OR_GREATER
+        [Test]
+        public void WriteReadByteSpan()
+        {
+            Span<byte> tempBytes = new byte[] { 1, 2, 4, 8 };
+            var ndw = new NetDataWriter();
+            ndw.Put(tempBytes);
+            Span<byte> anotherTempBytes = new byte[] { 16, byte.MaxValue, byte.MinValue };
+            ndw.Put(anotherTempBytes);
+
+            var ndr = new NetDataReader(ndw.Data);
+            var readByteArray = new byte[7];
+            ndr.GetBytes(readByteArray, 7);
+
+            Assert.That(
+                new byte[] { 1, 2, 4, 8, 16, byte.MaxValue, byte.MinValue },
+                Is.EqualTo(readByteArray).AsCollection);
+        }
+#endif
 
         [Test]
         public void WriteReadDouble()

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -418,6 +418,26 @@ namespace LiteNetLib
             NetDebug.Write(NetLogLevel.Trace, $"[CC] ConnectId: {_connectTime}, ConnectNum: {connectNum}");
         }
 
+#if LITENETLIB_SPANS || NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NETSTANDARD2_1
+        //"Connect to" constructor
+        internal NetPeer(NetManager netManager, IPEndPoint remoteEndPoint, int id, byte connectNum, ReadOnlySpan<byte> connectData)
+            : this(netManager, remoteEndPoint, id)
+        {
+            _connectTime = DateTime.UtcNow.Ticks;
+            _connectionState = ConnectionState.Outgoing;
+            ConnectionNum = connectNum;
+
+            //Make initial packet
+            _connectRequestPacket = NetConnectRequestPacket.Make(connectData, remoteEndPoint.Serialize(), _connectTime, id);
+            _connectRequestPacket.ConnectionNumber = connectNum;
+
+            //Send request
+            NetManager.SendRaw(_connectRequestPacket, this);
+
+            NetDebug.Write(NetLogLevel.Trace, $"[CC] ConnectId: {_connectTime}, ConnectNum: {connectNum}");
+        }
+#endif
+
         //"Accept" incoming constructor
         internal NetPeer(NetManager netManager, ConnectionRequest request, int id)
             : this(netManager, request.RemoteEndPoint, id)

--- a/LiteNetLib/Utils/NetDataWriter.cs
+++ b/LiteNetLib/Utils/NetDataWriter.cs
@@ -81,6 +81,18 @@ namespace LiteNetLib.Utils
             return netDataWriter;
         }
 
+#if LITENETLIB_SPANS || NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NETSTANDARD2_1
+        /// <summary>
+        /// Creates NetDataWriter from the given <paramref name="bytes"/>.
+        /// </summary>
+        public static NetDataWriter FromBytes(Span<byte> bytes)
+        {
+            var netDataWriter = new NetDataWriter(true, bytes.Length);
+            netDataWriter.Put(bytes);
+            return netDataWriter;
+        }
+#endif
+
         public static NetDataWriter FromString(string value)
         {
             var netDataWriter = new NetDataWriter();
@@ -248,6 +260,16 @@ namespace LiteNetLib.Utils
             Buffer.BlockCopy(data, 0, _data, _position, data.Length);
             _position += data.Length;
         }
+
+#if LITENETLIB_SPANS || NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NETSTANDARD2_1
+        public void Put(ReadOnlySpan<byte> data)
+        {
+            if (_autoResize)
+                ResizeIfNeed(_position + data.Length);
+            data.CopyTo(_data.AsSpan(_position));
+            _position += data.Length;
+        }
+#endif
 
         public void PutSBytesWithLength(sbyte[] data, int offset, ushort length)
         {


### PR DESCRIPTION
the availability of span overloads is great and really useful. there was just a few missing API that i need for my work:
- connecting with a span of bytes (2b0d8c04b276a5e1006530352b09e8fb1d28ea80)
```cs
Span<byte> connectionData = stackalloc byte[32];
//write data into connectionData manually
NetManager client = new();
client.Start();
client.Connect("localhost", 1337, connectionData);
```
- putting a span of bytes into a `NetDataWriter` (2eb2cbe1c082d3f4c760a3f0c70b9f8e7eb0baa9)
```cs
Span<byte> messageData = stackalloc byte[32];
NetDataWriter netWriter = new();
netWriter.Put(messageData);
netPeer.Send(netWriter, DeliveryMethod.ReliableOrdered);
```

tests were also added to check sanity check both under the `NET5_0_OR_GREATER` flags