### PR TITLE
Fix NativeAddress update bug in FinishEndPointChange method

### DIFF
--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -271,13 +271,13 @@ namespace LiteNetLib
             Address = newEndPoint.Address;
             Port = newEndPoint.Port;
 
+            _cachedSocketAddr = base.Serialize();            
             if (NetManager.UseNativeSockets)
             {
                 NativeAddress = new byte[_cachedSocketAddr.Size];
                 for (int i = 0; i < _cachedSocketAddr.Size; i++)
                     NativeAddress[i] = _cachedSocketAddr[i];
             }
-            _cachedSocketAddr = base.Serialize();
 #if NET8_0_OR_GREATER
             _cachedHashCode = NetManager.UseNativeSockets ? base.GetHashCode() : _cachedSocketAddr.GetHashCode();
 #else


### PR DESCRIPTION
# Bug description
## Setup
Unity client connecting to C# server
Unity client changes network (wifi/mobile etc)
Server has `AllowPeerAddressChange = true` and `UseNativeSockets = true`

I was experiencing that the server notices the address change but the client does not receive packets after the `PeerNotFound` packets.

The order of operations was different in the constructor and `FinishEndPointChange`, causing the `NativeAddress` to be set using the old `_cachedSocketAddr`. The NetPeer looks like it is sending to the new client IP/port, but is actually still using the old one.

# Change
Reordered _cachedSocketAddr assignment to occur before NativeAddress population, ensuring NativeAddress contains updated endpoint data rather than stale data during successful endpoint changes.