### PR TITLE
Feature: Allow simulating outbound networking

### DIFF
--- a/LiteNetLib/LiteNetLib.csproj
+++ b/LiteNetLib/LiteNetLib.csproj
@@ -26,6 +26,10 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SimulateNetwork)'=='true'">
+    <DefineConstants>$(DefineConstants);SIMULATE_NETWORK</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LITENETLIB_UNSAFE</DefineConstants>

--- a/LiteNetLib/NetManager.cs
+++ b/LiteNetLib/NetManager.cs
@@ -193,12 +193,12 @@ namespace LiteNetLib
         public int DisconnectTimeout = 5000;
 
         /// <summary>
-        /// Simulate packet loss by dropping random amount of packets. (Works only in DEBUG mode)
+        /// Simulate packet loss by dropping random amount of packets. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)
         /// </summary>
         public bool SimulatePacketLoss = false;
 
         /// <summary>
-        /// Simulate latency by holding packets for random time. (Works only in DEBUG mode)
+        /// Simulate latency by holding packets for random time. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)
         /// </summary>
         public bool SimulateLatency = false;
 
@@ -614,7 +614,7 @@ namespace LiteNetLib
             stopwatch.Stop();
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("DEBUG"), Conditional("SIMULATE_NETWORK")]
         private void ProcessDelayedPackets()
         {
             if (!SimulateLatency)
@@ -816,7 +816,7 @@ namespace LiteNetLib
             HandleMessageReceived(packet, remoteEndPoint);
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("DEBUG"), Conditional("SIMULATE_NETWORK")]
         private void HandleSimulateLatency(NetPacket packet, IPEndPoint remoteEndPoint)
         {
             if (!SimulateLatency)
@@ -841,7 +841,7 @@ namespace LiteNetLib
             }
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("DEBUG"), Conditional("SIMULATE_NETWORK")]
         private void HandleSimulatePacketLoss()
         {
             if (SimulatePacketLoss && _randomGenerator.NextDouble() * 100 < SimulationPacketLossChance)
@@ -1643,7 +1643,7 @@ namespace LiteNetLib
             _pendingEventTail = null;
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("DEBUG"), Conditional("SIMULATE_NETWORK")]
         private void ClearPingSimulationList()
         {
             lock (_pingSimulationList)

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -113,10 +113,10 @@ server.Stop();
   * (including library internal keepalive packets)
   * default value: **5000 msec**.
 * **SimulatePacketLoss**
-  * simulate packet loss by dropping random amout of packets. (Works only in DEBUG mode)
+  * simulate packet loss by dropping random amout of packets. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)
   * default value: **false**
 * **SimulateLatency**
-  * simulate latency by holding packets for random time. (Works only in DEBUG mode)
+  * simulate latency by holding packets for random time. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)
   * default value: **false**
 * **SimulationPacketLossChance**
   * chance of packet loss when simulation enabled. value in percents.

--- a/docs/api/LiteNetLib.NetManager.html
+++ b/docs/api/LiteNetLib.NetManager.html
@@ -586,7 +586,7 @@ If the DontRoute flag is set to True, then data will be delivered on the local s
 
 
   <h4 id="LiteNetLib_NetManager_SimulateLatency" data-uid="LiteNetLib.NetManager.SimulateLatency">SimulateLatency</h4>
-  <div class="markdown level1 summary"><p>Simulate latency by holding packets for random time. (Works only in DEBUG mode)</p>
+  <div class="markdown level1 summary"><p>Simulate latency by holding packets for random time. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="declaration">Declaration</h5>
@@ -611,7 +611,7 @@ If the DontRoute flag is set to True, then data will be delivered on the local s
 
 
   <h4 id="LiteNetLib_NetManager_SimulatePacketLoss" data-uid="LiteNetLib.NetManager.SimulatePacketLoss">SimulatePacketLoss</h4>
-  <div class="markdown level1 summary"><p>Simulate packet loss by dropping random amount of packets. (Works only in DEBUG mode)</p>
+  <div class="markdown level1 summary"><p>Simulate packet loss by dropping random amount of packets. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="declaration">Declaration</h5>


### PR DESCRIPTION
# Summary
This PR allows simulating packet loss and delay of outbound packets in addition to the existing inbound latency & loss.
It also adds a new SIMULATE_NETWORK compiler flag that enables network latency and packet loss simulation features in release builds, providing an alternative to requiring DEBUG mode.

# Background
We need to be able to test packet loss from the client to the server, and doing this per client is practical compared to setting simulation delay/loss on the server (which applies to all clients).

We are also building internal release builds in Unity and want the ability to simulate latency and packet loss in these builds. Being able to add this debug code without defining DEBUG seems practical and powerful.

# Implementation
I have hooked into `NetManager.SendRaw` to allow dropped/delayed packets to respect resending etc.


I have not attempted to change or merge this outbound latency/loss with the existing inbound latency/loss although this seems like a natural next step if you're considering merging this. One could imaging that setting SimulatedLatency would use 1/2 of this value for both inbound and outbound, and that loss would apply to both inbound and outbound packets.

Let me know if you're interested in this at all and I can do the remaining work.

Thanks again for a great library!

