### PR TITLE
Fix wording of comment in code about SimulatePacketLoss only works in debug build AND when simulate_network is defined.

### DIFF
--- a/LiteNetLib/LiteNetManager.cs
+++ b/LiteNetLib/LiteNetManager.cs
@@ -125,12 +125,12 @@ namespace LiteNetLib
         public int DisconnectTimeout = 5000;
 
         /// <summary>
-        /// Simulate packet loss by dropping random amount of packets. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)
+        /// Simulate packet loss by dropping random amount of packets. (Works only in DEBUG builds and when SIMULATE_NETWORK is defined)
         /// </summary>
         public bool SimulatePacketLoss = false;
 
         /// <summary>
-        /// Simulate latency by holding packets for random time. (Works only in DEBUG builds or when SIMULATE_NETWORK is defined)
+        /// Simulate latency by holding packets for random time. (Works only in DEBUG builds and when SIMULATE_NETWORK is defined)
         /// </summary>
         public bool SimulateLatency = false;
 


### PR DESCRIPTION
Fix wording of comment in code about SimulatePacketLoss only works in debug build AND when simulate_network is defined.

See https://github.com/RevenantX/LiteNetLib/issues/546