### PR TITLE
fix(LiteNetPeer): get packets count in reliable unordered channel

### DIFF
--- a/LiteNetLib/LiteNetPeer.cs
+++ b/LiteNetLib/LiteNetPeer.cs
@@ -339,7 +339,7 @@ namespace LiteNetLib
         /// <param name="ordered">type of channel ReliableOrdered or ReliableUnordered</param>
         /// <returns>packets count in channel queue</returns>
         public int GetPacketsCountInReliableQueue(bool ordered) =>
-            _reliableChannel?.PacketsInQueue ?? 0;
+            (ordered ? _reliableChannel : _reliableUnorderedChannel)?.PacketsInQueue ?? 0;
 
         /// <summary>
         /// Create temporary packet (maximum size MTU - headerSize) to send later without additional copies


### PR DESCRIPTION
While going through LiteNetLib, I noticed that `GetPacketsCountInReliableQueue` in `LiteNetPeer` accepts the argument `ordered`. Based on the comments, this argument should determine which channel, `ReliableOrdered` or `ReliableUnordered`, the number of packets in queue should come from. However, it appears that the count is always coming from the `ReliableOrdered` channel despite the value passed in for `ordered`. This PR aims to fix this behavior by returning the packet count for the `ReliableUnordered` channel if `ordered` is `false`.

I also made the argument default to `true` as well.