### PR TITLE
Add ReadOnlySpan<byte> overloads to Reject/Disconnect methods

### DIFF
--- a/LiteNetLib/ConnectionRequest.cs
+++ b/LiteNetLib/ConnectionRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading;
 using LiteNetLib.Utils;
 
@@ -76,10 +77,10 @@ namespace LiteNetLib
                 NetDebug.WriteError("[AC] Invalid incoming data");
             }
             if (Result == ConnectionRequestResult.Accept)
-                return _listener.OnConnectionSolved(this, null, 0, 0);
+                return _listener.OnConnectionSolved(this, ReadOnlySpan<byte>.Empty);
 
             Result = ConnectionRequestResult.Reject;
-            _listener.OnConnectionSolved(this, null, 0, 0);
+            _listener.OnConnectionSolved(this, ReadOnlySpan<byte>.Empty);
             return null;
         }
 
@@ -92,7 +93,23 @@ namespace LiteNetLib
             if (!TryActivate())
                 return null;
             Result = ConnectionRequestResult.Accept;
-            return _listener.OnConnectionSolved(this, null, 0, 0);
+            return _listener.OnConnectionSolved(this, ReadOnlySpan<byte>.Empty);
+        }
+
+        /// <summary>
+        /// Rejects the connection request.
+        /// </summary>
+        /// <param name="rejectData">Optional user data to send along with the rejection packet.</param>
+        /// <param name="force">
+        /// If <see langword="true"/>, immediately removes the request, if <paramref name="rejectData"/> is not empty a reject packet is also sent. <br/>
+        /// If <see langword="false"/>, creates a temporary peer that sends rejection packets and lingers in memory until a timeout occurs to handle late-arriving packets.
+        /// </param>
+        public void Reject(ReadOnlySpan<byte> rejectData, bool force)
+        {
+            if (!TryActivate())
+                return;
+            Result = force ? ConnectionRequestResult.RejectForce : ConnectionRequestResult.Reject;
+            _listener.OnConnectionSolved(this, rejectData);
         }
 
         /// <summary>
@@ -105,13 +122,8 @@ namespace LiteNetLib
         /// If <see langword="true"/>, immediately removes the request, if <paramref name="rejectData"/> is not <see langword="null"/> a reject packet is also sent. <br/>
         /// If <see langword="false"/>, creates a temporary peer that sends rejection packets and lingers in memory until a timeout occurs to handle late-arriving packets.
         /// </param>
-        public void Reject(byte[] rejectData, int start, int length, bool force)
-        {
-            if (!TryActivate())
-                return;
-            Result = force ? ConnectionRequestResult.RejectForce : ConnectionRequestResult.Reject;
-            _listener.OnConnectionSolved(this, rejectData, start, length);
-        }
+        public void Reject(byte[] rejectData, int start, int length, bool force) =>
+            Reject(new ReadOnlySpan<byte>(rejectData, start, length), force);
 
         /// <summary>
         /// Rejects the connection reliably. Creates a temporary peer to handle packet loss.
@@ -120,7 +132,7 @@ namespace LiteNetLib
         /// <param name="start">Offset in the <paramref name="rejectData"/> array.</param>
         /// <param name="length">Length of the data to be sent.</param>
         public void Reject(byte[] rejectData, int start, int length) =>
-            Reject(rejectData, start, length, false);
+            Reject(new ReadOnlySpan<byte>(rejectData, start, length), false);
 
         /// <summary>
         /// Rejects the connection immediately without reliability.
@@ -130,47 +142,61 @@ namespace LiteNetLib
         /// <param name="start">Offset in the <paramref name="rejectData"/> array.</param>
         /// <param name="length">Length of the data to be sent.</param>
         public void RejectForce(byte[] rejectData, int start, int length) =>
-            Reject(rejectData, start, length, true);
+            Reject(new ReadOnlySpan<byte>(rejectData, start, length), true);
 
         /// <summary>
         /// Rejects the connection immediately without sending any packet.
         /// </summary>
         public void RejectForce() =>
-            Reject(null, 0, 0, true);
+            Reject(ReadOnlySpan<byte>.Empty, true);
 
         /// <summary>
         /// Rejects the connection immediately without reliability.
         /// </summary>
         /// <param name="rejectData">Data to send with the rejection.</param>
         public void RejectForce(byte[] rejectData) =>
-            Reject(rejectData, 0, rejectData.Length, true);
+            Reject(new ReadOnlySpan<byte>(rejectData), true);
 
         /// <summary>
         /// Rejects the connection immediately without reliability using data from a <see cref="NetDataWriter"/>.
         /// </summary>
         /// <param name="rejectData">Writer containing the data to send.</param>
         public void RejectForce(NetDataWriter rejectData) =>
-            Reject(rejectData.Data, 0, rejectData.Length, true);
+            Reject(rejectData.AsReadOnlySpan(), true);
+
+        /// <summary>
+        /// Rejects the connection immediately without reliability.
+        /// </summary>
+        /// <param name="rejectData">Data to send with the rejection.</param>
+        public void RejectForce(ReadOnlySpan<byte> rejectData) =>
+            Reject(rejectData, true);
 
         /// <summary>
         /// Rejects the connection reliably without additional data.
         /// </summary>
         public void Reject() =>
-            Reject(null, 0, 0, false);
+            Reject(ReadOnlySpan<byte>.Empty, false);
 
         /// <summary>
         /// Rejects the connection reliably.
         /// </summary>
         /// <param name="rejectData">Data to send with the rejection.</param>
         public void Reject(byte[] rejectData) =>
-            Reject(rejectData, 0, rejectData.Length, false);
+            Reject(new ReadOnlySpan<byte>(rejectData), false);
 
         /// <summary>
         /// Rejects the connection reliably using data from a <see cref="NetDataWriter"/>.
         /// </summary>
         /// <param name="rejectData">Writer containing the data to send.</param>
         public void Reject(NetDataWriter rejectData) =>
-            Reject(rejectData.Data, 0, rejectData.Length, false);
+            Reject(rejectData.AsReadOnlySpan(), false);
+
+        /// <summary>
+        /// Rejects the connection reliably.
+        /// </summary>
+        /// <param name="rejectData">Data to send with the rejection.</param>
+        public void Reject(ReadOnlySpan<byte> rejectData) =>
+            Reject(rejectData, false);
     }
 
     public class ConnectionRequest : LiteConnectionRequest

--- a/LiteNetLib/LiteNetManager.cs
+++ b/LiteNetLib/LiteNetManager.cs
@@ -313,7 +313,7 @@ namespace LiteNetLib
             DisconnectReason reason,
             SocketError socketErrorCode,
             NetPacket eventData) =>
-            DisconnectPeer(peer, reason, socketErrorCode, true, null, 0, 0, eventData);
+            DisconnectPeer(peer, reason, socketErrorCode, true, ReadOnlySpan<byte>.Empty, eventData);
 
         /// <summary>
         /// Disconnects a peer and handles internal state cleanup.
@@ -327,20 +327,16 @@ namespace LiteNetLib
         /// Peer will linger until <see cref="DisconnectTimeout"/> to ignore late-arriving packets from the old session.
         /// </param>
         /// <param name="data">Optional custom data to include in the disconnect packet.</param>
-        /// <param name="start">Offset in the <paramref name="data"/> array.</param>
-        /// <param name="count">Number of bytes to send from the <paramref name="data"/> array.</param>
         /// <param name="eventData">Internal packet data associated with the disconnect event.</param>
         private void DisconnectPeer(
             LiteNetPeer peer,
             DisconnectReason reason,
             SocketError socketErrorCode,
             bool force,
-            byte[] data,
-            int start,
-            int count,
+            ReadOnlySpan<byte> data,
             NetPacket eventData)
         {
-            var shutdownResult = peer.Shutdown(data, start, count, force);
+            var shutdownResult = peer.Shutdown(data, force);
             if (shutdownResult == ShutdownResult.None)
                 return;
             if (shutdownResult == ShutdownResult.WasConnected)
@@ -631,22 +627,22 @@ namespace LiteNetLib
         protected virtual LiteConnectionRequest CreateConnectionRequest(IPEndPoint remoteEndPoint, NetConnectRequestPacket requestPacket) =>
             new LiteConnectionRequest(remoteEndPoint, requestPacket, this);
 
-        internal LiteNetPeer OnConnectionSolved(LiteConnectionRequest request, byte[] rejectData, int start, int length)
+        internal LiteNetPeer OnConnectionSolved(LiteConnectionRequest request, ReadOnlySpan<byte> rejectData)
         {
             LiteNetPeer netPeer = null;
 
             if (request.Result == ConnectionRequestResult.RejectForce)
             {
                 NetDebug.Write(NetLogLevel.Trace, "[NM] Peer connect reject force.");
-                if (rejectData != null && length > 0)
+                if (!rejectData.IsEmpty)
                 {
-                    var shutdownPacket = PoolGetWithProperty(PacketProperty.Disconnect, length);
+                    var shutdownPacket = PoolGetWithProperty(PacketProperty.Disconnect, rejectData.Length);
                     shutdownPacket.ConnectionNumber = request.InternalPacket.ConnectionNumber;
                     FastBitConverter.GetBytes(shutdownPacket.RawData, 1, request.InternalPacket.ConnectionTime);
                     if (shutdownPacket.Size >= NetConstants.PossibleMtu[0])
                         NetDebug.WriteError("[Peer] Disconnect additional data size more than MTU!");
                     else
-                        Buffer.BlockCopy(rejectData, start, shutdownPacket.RawData, 9, length);
+                        rejectData.CopyTo(shutdownPacket.RawData.AsSpan(9));
                     SendRawAndRecycle(shutdownPacket, request.RemoteEndPoint);
                 }
                 lock (_requestsDict)
@@ -661,7 +657,7 @@ namespace LiteNetLib
                 else if (request.Result == ConnectionRequestResult.Reject)
                 {
                     netPeer = CreateRejectPeer(request.RemoteEndPoint, GetNextPeerId());
-                    netPeer.Reject(request.InternalPacket, rejectData, start, length);
+                    netPeer.Reject(request.InternalPacket, rejectData);
                     AddPeer(netPeer);
                     NetDebug.Write(NetLogLevel.Trace, "[NM] Peer connect reject.");
                 }
@@ -1490,7 +1486,7 @@ namespace LiteNetLib
 
             //Send last disconnect
             for (var netPeer = _headPeer; netPeer != null; netPeer = netPeer.NextPeer)
-                netPeer.Shutdown(null, 0, 0, !sendDisconnectMessages);
+                netPeer.Shutdown(ReadOnlySpan<byte>.Empty, !sendDisconnectMessages);
 
             //Stop
             CloseSocket();
@@ -1576,7 +1572,7 @@ namespace LiteNetLib
         /// Disconnect all peers without any additional data
         /// </summary>
         public void DisconnectAll() =>
-            DisconnectAll(null, 0, 0);
+            DisconnectAll(ReadOnlySpan<byte>.Empty);
 
         /// <summary>
         /// Disconnect all peers with shutdown message
@@ -1584,7 +1580,14 @@ namespace LiteNetLib
         /// <param name="data">Data to send (must be less or equal MTU)</param>
         /// <param name="start">Data start</param>
         /// <param name="count">Data count</param>
-        public void DisconnectAll(byte[] data, int start, int count)
+        public void DisconnectAll(byte[] data, int start, int count) =>
+            DisconnectAll(new ReadOnlySpan<byte>(data, start, count));
+
+        /// <summary>
+        /// Disconnect all peers with shutdown message
+        /// </summary>
+        /// <param name="data">Data to send (must be less or equal MTU)</param>
+        public void DisconnectAll(ReadOnlySpan<byte> data)
         {
             //Send disconnect packets
             _peersLock.EnterReadLock();
@@ -1596,8 +1599,6 @@ namespace LiteNetLib
                     0,
                     false,
                     data,
-                    start,
-                    count,
                     null);
             }
             _peersLock.ExitReadLock();
@@ -1615,7 +1616,7 @@ namespace LiteNetLib
         /// </summary>
         /// <param name="peer">peer to disconnect</param>
         public void DisconnectPeer(LiteNetPeer peer) =>
-            DisconnectPeer(peer, null, 0, 0);
+            DisconnectPeer(peer, ReadOnlySpan<byte>.Empty);
 
         /// <summary>
         /// Disconnect peer from server and send additional data (Size must be less or equal MTU - 8)
@@ -1623,7 +1624,7 @@ namespace LiteNetLib
         /// <param name="peer">peer to disconnect</param>
         /// <param name="data">additional data</param>
         public void DisconnectPeer(LiteNetPeer peer, byte[] data) =>
-            DisconnectPeer(peer, data, 0, data.Length);
+            DisconnectPeer(peer, new ReadOnlySpan<byte>(data));
 
         /// <summary>
         /// Disconnect peer from server and send additional data (Size must be less or equal MTU - 8)
@@ -1631,7 +1632,7 @@ namespace LiteNetLib
         /// <param name="peer">peer to disconnect</param>
         /// <param name="writer">additional data</param>
         public void DisconnectPeer(LiteNetPeer peer, NetDataWriter writer) =>
-            DisconnectPeer(peer, writer.Data, 0, writer.Length);
+            DisconnectPeer(peer, writer.AsReadOnlySpan());
 
         /// <summary>
         /// Disconnect peer from server and send additional data (Size must be less or equal MTU - 8)
@@ -1640,7 +1641,15 @@ namespace LiteNetLib
         /// <param name="data">additional data</param>
         /// <param name="start">data start</param>
         /// <param name="count">data length</param>
-        public void DisconnectPeer(LiteNetPeer peer, byte[] data, int start, int count)
+        public void DisconnectPeer(LiteNetPeer peer, byte[] data, int start, int count) =>
+            DisconnectPeer(peer, new ReadOnlySpan<byte>(data, start, count));
+
+        /// <summary>
+        /// Disconnect peer from server and send additional data (Size must be less or equal MTU - 8)
+        /// </summary>
+        /// <param name="peer">peer to disconnect</param>
+        /// <param name="data">additional data</param>
+        public void DisconnectPeer(LiteNetPeer peer, ReadOnlySpan<byte> data)
         {
             DisconnectPeer(
                 peer,
@@ -1648,8 +1657,6 @@ namespace LiteNetLib
                 0,
                 false,
                 data,
-                start,
-                count,
                 null);
         }
 

--- a/LiteNetLib/LiteNetPeer.cs
+++ b/LiteNetLib/LiteNetPeer.cs
@@ -446,11 +446,11 @@ namespace LiteNetLib
         }
 
         //Reject
-        internal void Reject(NetConnectRequestPacket requestData, byte[] data, int start, int length)
+        internal void Reject(NetConnectRequestPacket requestData, ReadOnlySpan<byte> data)
         {
             _connectTime = requestData.ConnectionTime;
             _connectNum = requestData.ConnectionNumber;
-            Shutdown(data, start, length, false);
+            Shutdown(data, false);
         }
 
         internal bool ProcessConnectAccept(NetConnectAcceptPacket packet)
@@ -698,6 +698,9 @@ namespace LiteNetLib
         public void Disconnect(byte[] data, int start, int count) =>
             NetManager.DisconnectPeer(this, data, start, count);
 
+        public void Disconnect(ReadOnlySpan<byte> data) =>
+            NetManager.DisconnectPeer(this, data);
+
         public void Disconnect() =>
             NetManager.DisconnectPeer(this);
 
@@ -724,15 +727,13 @@ namespace LiteNetLib
         /// Internally handles the shutdown process for this peer.
         /// </summary>
         /// <param name="data">Optional data to include in the unreliable disconnect packet.</param>
-        /// <param name="start">Offset in the <paramref name="data"/> array.</param>
-        /// <param name="length">Length of the data to send.</param>
         /// <param name="force">
         /// If <see langword="true"/>, immediately sets state to <see cref="ConnectionState.Disconnected"/> without sending a notification. <br/>
         /// If <see langword="false"/>, sends unreliable disconnect packets until a timeout occurs and sets state to <see cref="ConnectionState.ShutdownRequested"/>
         /// Queued reliable packets are bypassed and dropped immediately.
         /// </param>
         /// <returns>A <see cref="ShutdownResult"/> indicating the state change transition.</returns>
-        internal ShutdownResult Shutdown(byte[] data, int start, int length, bool force)
+        internal ShutdownResult Shutdown(ReadOnlySpan<byte> data, bool force)
         {
             lock (_shutdownLock)
             {
@@ -758,16 +759,16 @@ namespace LiteNetLib
                 Interlocked.Exchange(ref _timeSinceLastPacket, 0);
 
                 //send shutdown packet
-                _shutdownPacket = new NetPacket(PacketProperty.Disconnect, length) {ConnectionNumber = _connectNum};
+                _shutdownPacket = new NetPacket(PacketProperty.Disconnect, data.Length) {ConnectionNumber = _connectNum};
                 FastBitConverter.GetBytes(_shutdownPacket.RawData, 1, _connectTime);
                 if (_shutdownPacket.Size >= _mtu)
                 {
                     //Drop additional data
                     NetDebug.WriteError("[Peer] Disconnect additional data size more than MTU - 8!");
                 }
-                else if (data != null && length > 0)
+                else if (!data.IsEmpty)
                 {
-                    Buffer.BlockCopy(data, start, _shutdownPacket.RawData, 9, length);
+                    data.CopyTo(_shutdownPacket.RawData.AsSpan(9));
                 }
                 _connectionState = ConnectionState.ShutdownRequested;
                 NetDebug.Write("[Peer] Send disconnect");


### PR DESCRIPTION
Added `ReadOnlySpan<byte>` overloads to the following methods:
`LiteConnectionRequest.Reject/RejectForce`
`LiteNetManager.DisconnectPeer/DisconnectAll`
`LiteNetPeer.Disconnect`

Updated all existing array-based overloads of the above methods to forward through the span-based implementations.
Updated the internal method implementations at the end of the relevant call paths (`LiteNetPeer.Shutdown`, `LiteNetManager.OnConnectionSolved`) to use `ReadOnlySpan<byte>`.

Technically makes rejections/disconnects more performant, but in practice this probably won't be measurable since this isn't typically a hot path. `ReadOnlySpan.CopyTo` with small data sizes will outperform `Buffer.BlockCopy` thanks to intrinsics unrolling the copy and eliminating bound safety checks. The reality is I updated the internal methods simply because it was required for the public methods' compatibility.